### PR TITLE
feat: user_idに既存ルーティング（予約語）を登録できないように変更

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,4 @@
 Rails.application.routes.draw do
-  # ユーザー詳細ページ（/users/:user_id）
-  resources :users, only: [ :show ], param: :user_id
-
-
   # ユーザープロフィール用のルーティング
   resource :profile, only: [ :show, :edit, :update, :destroy ]
 
@@ -10,6 +6,9 @@ Rails.application.routes.draw do
   devise_for :users, controllers: {
     omniauth_callbacks: "users/omniauth_callbacks"
   }
+
+  # ユーザー詳細ページ（/users/:user_id）
+  resources :users, only: [ :show ], param: :user_id
 
   get "static_pages/index"
 

--- a/test/controllers/profiles_controller_test.rb
+++ b/test/controllers/profiles_controller_test.rb
@@ -44,6 +44,15 @@ class ProfilesControllerTest < ActionDispatch::IntegrationTest
     assert_response :unprocessable_entity
   end
 
+  # user_idが予約語の場合のプロフィール更新テスト
+  test "should not update user_id when reserved word" do
+    patch profile_url, params: { user: { user_id: "sign_in" } }
+    @user.reload
+    assert_not_equal "sign_in", @user.user_id
+    # HTTPステータスが422（バリデーションエラー）であることを確認
+    assert_response :unprocessable_entity
+  end
+
   # プロフィール更新後のリダイレクトのテスト
   test "should redirect after update profile when logged in" do
     # PATCHリクエスト（プロフィール更新処理）


### PR DESCRIPTION
Closes: #89 