### PR TITLE
fix: スマホでスクロール時にイベントヘッダーが隠れてしまう問題を修正するため、イベントヘッダーをmain要素内に移動

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -30,8 +30,6 @@
     <%= render "layouts/header" %>
     <%# セカンドヘッダー（@page_title が設定されている場合のみ表示する） %>
     <%= render "layouts/secondary-header" %>
-    <%# イベント用ヘッダー(@show_event_headerがtrueの場合のみ表示) %>
-    <%= render "layouts/event-header" %>
     <%# 成功メッセージ %>
     <%= render "devise/shared/notice_messages" %>
     <%# メイン要素（@no_marginがtrueの場合はmainに対するマージンを取り除く） %>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -1,8 +1,10 @@
 <% if @performances.present? %>
-  <%# タイムテーブル表示画面のメインコンテナ（画面全体からヘッダーの高さを引いた高さに設定する） %>
-  <div class="h-[calc(100vh-3rem)] flex flex-col overflow-hidden">
+  <%# タイムテーブル表示画面のメインコンテナ（画面全体の高さに設定する） %>
+  <div class="h-screen flex flex-col overflow-hidden">
+    <%# イベント用ヘッダー(@show_event_headerがtrueの場合のみ表示) %>
+    <%= render "layouts/event-header" %>
     <%# 日付選択タブ %>
-    <nav class="flex h-8 sticky top-0 left-0 w-full justify-around overflow-x-auto bg-white border-t border-gray-200">
+    <nav class="flex h-8 sticky top-0 w-full justify-around overflow-x-auto bg-white border-t border-gray-200">
       <% @days.each do |day| %>
         <%# 日付を MM/DD 形式でラベルに整形 %>
         <% label = day.date.strftime("%-m/%-d") %>


### PR DESCRIPTION
Closes: #154 