### PR TITLE
fix: 出演情報が0件の場合タイムテーブルページを表示できないバグを修正し、テストを作成

### DIFF
--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -63,8 +63,10 @@ class TimetablesController < ApplicationController
 
     # 選択された開催日をセット
     def set_selected_date
-      # クエリパラメータから日付を決定
-      @selected_date = params[:d].present? ? Date.parse(params[:d]) : @days.first.date
+      if @days.present?
+        # クエリパラメータから日付を決定
+        @selected_date = params[:d].present? ? Date.parse(params[:d]) : @days.first.date
+      end
     end
 
     # タイムテーブル描画に必要な情報がすべて揃った performance を取得

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -72,8 +72,10 @@
     </div>
   </div>
 <% else %>
-  <%# 情報が揃った出演情報が0件の場合 %>
-  <div class="text-center text-bold">
+  <%# ===== 情報が揃った出演情報が0件の場合 ===== %>
+  <div class="h-svh pt-12 flex items-center justify-center text-bold pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
     <p>出演情報がありません</p>
   </div>
+  <%# 下部タブメニュー %>
+  <%= render "layouts/bottom_tab" %>
 <% end %>

--- a/test/controllers/timetables_controller_test.rb
+++ b/test/controllers/timetables_controller_test.rb
@@ -11,6 +11,7 @@ class TimetablesControllerTest < ActionDispatch::IntegrationTest
     # テスト用のログイン状態を再現
     sign_in @user
     @event = events(:one)
+    @no_performance_event = events(:no_performance_event)
     @day1 = days(:one)
     @day2 = days(:two)
     @performance1 = performances(:one)
@@ -58,5 +59,11 @@ class TimetablesControllerTest < ActionDispatch::IntegrationTest
     sign_in @user_two
     get edit_timetable_url(@event.event_key)
     assert_response :not_found
+  end
+
+  # 出演情報が0件の場合もタイムテーブルを表示できる
+  test "should show event timetable by event_key when no performances" do
+    get "/#{@no_performance_event.event_key}"
+    assert_response :success
   end
 end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -25,3 +25,10 @@ four:
   event_key: "four"
   description: "テスト用フェスイベント"
   is_published: true
+
+no_performance_event:
+  user: two
+  event_name_tag: one
+  event_key: "no_performance_event"
+  description: "出演情報がないテスト用フェスイベント"
+  is_published: true


### PR DESCRIPTION
Closes: #164 