### PR TITLE
fix: タイムテーブル削除後の遷移先を作成したタイムテーブル一覧ページに修正

### DIFF
--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -103,7 +103,7 @@ class EventsController < ApplicationController
   # 削除処理
   def destroy
     @event.destroy!
-    redirect_to events_path, notice: "タイムテーブルを削除しました"
+    redirect_to events_path(filter: "created"), notice: "タイムテーブルを削除しました"
   end
 
   private

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -157,7 +157,7 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_difference("Event.count", -1) do
       delete event_url(@event.event_key)
     end
-    assert_redirected_to events_path
+    assert_redirected_to events_path(filter: "created")
   end
 
   # 他人のイベント削除は失敗し、Event.count は変化しない


### PR DESCRIPTION
Closes: #378 