### PR TITLE
chore: Dependabot PRの自動マージworkflowを追加

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Enable auto-merge for bundler-updates
+        if: steps.metadata.outputs.dependency-group == 'bundler-updates'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- `bundler-updates` グループの Dependabot PR に対して auto-merge を有効化する Workflow を追加
- `dependabot/fetch-metadata` で PR の依存グループを判定し、対象PRのみ `gh pr merge --auto --squash` を実行
- GitHub リポジトリ設定の Auto-merge と required status checks を前提に、CI通過後に自動マージされるようにする

## Test plan
- [x] Dependabot が `bundler-updates` PR を作成したときに Workflow が起動すること
- [x] 対象PRで `Enable auto-merge for bundler-updates` が実行されること
- [x] 必須CIが成功後に PR が自動で squash merge されること
- [x] `bundler-security` や `actions-updates` PR では auto-merge ステップが実行されないこと

Made with [Cursor](https://cursor.com)