### PR TITLE
fix: 長いステージ名でスマホのステージ幅が広がる問題を修正

### DIFF
--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -32,8 +32,8 @@
           <% @stages.each do |stage| %>
             <%= link_to event_stage_path(@event.event_key, stage),
                 class: "stage-header-col flex-1 flex justify-center items-center
-                        min-h-8 max-h-12 min-w-16 z-95 border-b text-xs font-bold text-center p-px" do %>
-              <span class="line-clamp-3"><%= stage.stage_name_tag.name %></span>
+                        min-h-8 max-h-12 w-0 min-w-16 overflow-hidden z-95 border-b text-xs font-bold text-center p-px" do %>
+              <span class="line-clamp-3 wrap-break-word w-full"><%= stage.stage_name_tag.name %></span>
             <% end %>
           <% end %>
         </div>
@@ -49,7 +49,7 @@
           </div>
           <%# ステージを展開 %>
           <% @stages.each do |stage| %>
-            <div class="timetable-body-col flex-1 min-w-16 relative"
+            <div class="timetable-body-col flex-1 w-0 min-w-16 relative"
                 style="height: <%= timetable_height_rem(@performances) %>rem;">
               <%# 各ステージの出演情報を検索 %>
               <% if @performances_by_stage[stage.id].present? %>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -43,8 +43,8 @@
           <% @stages.each do |stage| %>
             <%= link_to event_stage_path(@event.event_key, stage),
                 class: "stage-header-col flex-1 flex justify-center items-center
-                        min-h-8 max-h-12 min-w-16 z-95 border-b text-xs font-bold text-center p-px" do %>
-              <span class="line-clamp-3"><%= stage.stage_name_tag.name %></span>
+                        min-h-8 max-h-12 w-0 min-w-16 overflow-hidden z-95 border-b text-xs font-bold text-center p-px" do %>
+              <span class="line-clamp-3 wrap-break-word w-full"><%= stage.stage_name_tag.name %></span>
             <% end %>
           <% end %>
         </div>
@@ -60,7 +60,7 @@
           </div>
           <%# ステージを展開 %>
           <% @stages.each do |stage| %>
-            <div class="timetable-body-col flex-1 min-w-16 relative"
+            <div class="timetable-body-col flex-1 w-0 min-w-16 relative"
                 style="height: <%= timetable_height_rem(@performances) %>rem;">
               <%# 各ステージの出演情報を検索 %>
               <% if @performances_by_stage[stage.id].present? %>


### PR DESCRIPTION
## Summary
- Fixes #363
- タイムテーブル／マイタイムテーブルのステージ列が、長いステージ名の内容幅（max-content）によって意図より広くなる問題を修正
- 親の `min-w-max` と flex 列の組み合わせが原因。列に `w-0`（＋ヘッダーは `overflow-hidden`、名前は `wrap-break-word w-full`）を付与し、内容幅の影響を打ち消す

## 原因
ステージ列は `flex-1 min-w-16`、親ラッパーは `min-w-max`（`min-width: max-content`）。

`min-w-max` は子の **max-content幅**（テキストを折り返さない想定の幅）を親の最小幅に使う。ステージ名が長いと、この値が `min-w-16`（64px）を大幅に超えて列全体が広がる。

`line-clamp-3` や `overflow-hidden` だけでは不十分。前者は「幅が決まっている前提」の見た目制御、後者は溢れの隠蔽であり、**max-content の計算自体は小さくならない**。

## 対応
対象: `app/views/timetables/show.html.erb` / `app/views/my_timetables/show.html.erb`

- ステージヘッダー: `w-0 min-w-16 overflow-hidden`、名前に `wrap-break-word w-full`
- ボディ列: `w-0 min-w-16`

`flex-1` による少数ステージ時の均等拡大、および多数ステージ時の `min-w-16` 下限＋横スクロールは維持。

## CursorによるChrome実測方法
レイアウトを切り出す最小HTMLを `/tmp/stage-width-repro*.html` に作成し、Tailwind CDN＋実DB相当の長いステージ名で再現。Google Chrome headless で DOM 描画後に `offsetWidth` を計測した。

```bash
"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" \
  --headless=new --disable-gpu --virtual-time-budget=8000 \
  --dump-dom "file:///tmp/stage-width-repro4.html" \
  | grep -E '<h2|<pre id="o'
```

スクロール親を幅375px（スマホ想定）に固定し、内側は本番同様 `min-w-max` + `flex` + ステージ列クラスを配置。JSで `wrap.offsetWidth` と各列の `offsetWidth` を出力して比較した。

## 検証結果（Chrome実測）
条件: ビューポート相当 375px、2列または6列

| 条件 | wrap幅 | 列幅 |
|------|--------|------|
| 短い名前（正常・2列） | 373px | 177px |
| 長い日本語名 + 修正前（2列） | **2069px** | **1025px** |
| 長い日本語名 + `overflow-hidden`のみ（2列） | **2069px** | **1025px**（解消せず） |
| 長い日本語名 + `w-0`（2列） | 373px | 177px |
| 短い名前（6列） | 404px | 64px × 6 |
| 長い名前 + `w-0`（6列） | 404px | 64px × 6 |

補足: 英単語がスペースなしで続く場合も `overflow-hidden` だけでは列が広がり、`w-0` で解消することを確認。

## Test plan
- [x] `/t/IkD2-wE6H2U`（長いステージ名のテストイベント）をスマホ幅で開き、ステージ幅が短い名前時と同程度になること
- [x] ステージ名が折り返し＋最大3行でクランプされること
- [x] ステージ数が少ない場合、列が画面幅いっぱいに均等拡大すること
- [x] ステージ数が多い場合（6以上）、列が `min-w-16` 程度を下限に横スクロールできること
- [x] マイタイムテーブルでも同様であること


Made with [Cursor](https://cursor.com)