### PR TITLE
feat: 開発者向けの簡易管理画面を追加する

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -6,6 +6,8 @@ class Admin::BaseController < ApplicationController
 
   # developer 以外は管理画面の存在を隠すため 404 にする
   def require_developer!
-    raise ActiveRecord::RecordNotFound unless current_user.developer?
+    return if current_user.developer?
+
+    render file: Rails.public_path.join("404.html"), layout: false, status: :not_found
   end
 end

--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -1,0 +1,11 @@
+class Admin::BaseController < ApplicationController
+  before_action :authenticate_user!
+  before_action :require_developer!
+
+  private
+
+  # developer 以外は管理画面の存在を隠すため 404 にする
+  def require_developer!
+    raise ActiveRecord::RecordNotFound unless current_user.developer?
+  end
+end

--- a/app/controllers/admin/dashboards_controller.rb
+++ b/app/controllers/admin/dashboards_controller.rb
@@ -1,0 +1,9 @@
+class Admin::DashboardsController < Admin::BaseController
+  def show
+    @page_title = "管理画面（開発者向け）"
+    @users_count = User.count
+    @users = User.order(created_at: :desc)
+    @events_count = Event.count
+    @events = Event.includes(:user, :event_name_tag).order(created_at: :desc)
+  end
+end

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -53,8 +53,8 @@
             <tr class="border-b border-gray-100">
               <td class="px-3 py-2"><%= event.id %></td>
               <td class="px-3 py-2">
-                <%= link_to event.display_name, event_path(event.event_key),
-                            class: "text-gray-800 hover:underline" %>
+                <%= link_to event.display_name, show_timetable_path(event.event_key),
+                            class: "text-blue-600 hover:underline" %>
               </td>
               <td class="px-3 py-2"><%= event.is_published? ? "公開" : "非公開" %></td>
               <td class="px-3 py-2"><%= event.user.name %>（<%= event.user.email %>）</td>

--- a/app/views/admin/dashboards/show.html.erb
+++ b/app/views/admin/dashboards/show.html.erb
@@ -1,0 +1,68 @@
+<% content_for :title, "#{@page_title} | みんなのタイムテーブル" %>
+<% content_for :description, "開発者向け管理画面。" %>
+<% content_for :head do %>
+  <meta name="robots" content="noindex, nofollow">
+<% end %>
+
+<div class="space-y-10">
+  <section>
+    <h2 class="mb-2 text-lg font-semibold text-gray-800">ユーザー</h2>
+    <p class="mb-4 text-sm text-gray-600">総数: <%= @users_count %></p>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm text-left text-gray-800 border border-gray-200">
+        <thead class="bg-gray-50 border-b border-gray-200">
+          <tr>
+            <th class="px-3 py-2 font-semibold">ID</th>
+            <th class="px-3 py-2 font-semibold">名前</th>
+            <th class="px-3 py-2 font-semibold">メールアドレス</th>
+            <th class="px-3 py-2 font-semibold">ロール</th>
+            <th class="px-3 py-2 font-semibold">作成日</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @users.each do |user| %>
+            <tr class="border-b border-gray-100">
+              <td class="px-3 py-2"><%= user.id %></td>
+              <td class="px-3 py-2"><%= user.name %></td>
+              <td class="px-3 py-2"><%= user.email %></td>
+              <td class="px-3 py-2"><%= user.role %></td>
+              <td class="px-3 py-2"><%= l(user.created_at.to_date, format: :default) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+
+  <section>
+    <h2 class="mb-2 text-lg font-semibold text-gray-800">タイムテーブル</h2>
+    <p class="mb-4 text-sm text-gray-600">総数: <%= @events_count %>（非公開含む）</p>
+    <div class="overflow-x-auto">
+      <table class="min-w-full text-sm text-left text-gray-800 border border-gray-200">
+        <thead class="bg-gray-50 border-b border-gray-200">
+          <tr>
+            <th class="px-3 py-2 font-semibold">ID</th>
+            <th class="px-3 py-2 font-semibold">名前</th>
+            <th class="px-3 py-2 font-semibold">公開</th>
+            <th class="px-3 py-2 font-semibold">作成者</th>
+            <th class="px-3 py-2 font-semibold">作成日</th>
+          </tr>
+        </thead>
+        <tbody>
+          <% @events.each do |event| %>
+            <tr class="border-b border-gray-100">
+              <td class="px-3 py-2"><%= event.id %></td>
+              <td class="px-3 py-2">
+                <%= link_to event.display_name, event_path(event.event_key),
+                            class: "text-gray-800 hover:underline" %>
+              </td>
+              <td class="px-3 py-2"><%= event.is_published? ? "公開" : "非公開" %></td>
+              <td class="px-3 py-2"><%= event.user.name %>（<%= event.user.email %>）</td>
+              <td class="px-3 py-2"><%= l(event.created_at.to_date, format: :default) %></td>
+            </tr>
+          <% end %>
+        </tbody>
+      </table>
+    </div>
+  </section>
+</div>

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -12,6 +12,10 @@
                     class: "text-gray-700 hover:text-gray-900 hover:underline",
                     target: "_blank",
                     rel: "noopener noreferrer" %>
+          <% if user_signed_in? && current_user.developer? %>
+            <%= link_to "管理画面（開発者向け）", admin_dashboard_path,
+                class: "text-gray-700 hover:text-gray-900 hover:underline" %>
+          <% end %>
           <div class="flex items-center text-gray-700">
             <span>運営：</span>
             <%= link_to "https://piku.page/@yyoshidaweb",

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,11 @@ Rails.application.routes.draw do
   # トップページ
   root to: "home#index"
 
+  # 開発者向け管理画面
+  namespace :admin do
+    resource :dashboard, only: [ :show ]
+  end
+
   # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
   # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check

--- a/test/controllers/admin/dashboards_controller_test.rb
+++ b/test/controllers/admin/dashboards_controller_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class Admin::DashboardsControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @developer = users(:developer)
+    @free_user = users(:one)
+  end
+
+  test "developer can access admin dashboard" do
+    sign_in @developer
+    get admin_dashboard_url
+    assert_response :success
+    assert_select "h2", text: "ユーザー"
+    assert_select "h2", text: "タイムテーブル"
+    assert_match @free_user.email, response.body
+    assert_match @free_user.name, response.body
+    assert_match events(:unpublished).display_name, response.body
+    assert_match "非公開", response.body
+  end
+
+  test "free user cannot access admin dashboard" do
+    sign_in @free_user
+    get admin_dashboard_url
+    assert_response :not_found
+  end
+
+  test "guest cannot access admin dashboard" do
+    get admin_dashboard_url
+    assert_redirected_to root_url
+  end
+
+  test "admin footer link is visible only for developer" do
+    sign_in @developer
+    get root_url
+    assert_select "a[href=?]", admin_dashboard_path, text: "管理画面（開発者向け）"
+
+    sign_out @developer
+    sign_in @free_user
+    get root_url
+    assert_select "a[href=?]", admin_dashboard_path, text: "管理画面（開発者向け）", count: 0
+
+    sign_out @free_user
+    get root_url
+    assert_select "a[href=?]", admin_dashboard_path, text: "管理画面（開発者向け）", count: 0
+  end
+end

--- a/test/controllers/admin/dashboards_controller_test.rb
+++ b/test/controllers/admin/dashboards_controller_test.rb
@@ -18,6 +18,8 @@ class Admin::DashboardsControllerTest < ActionDispatch::IntegrationTest
     assert_match @free_user.name, response.body
     assert_match events(:unpublished).display_name, response.body
     assert_match "非公開", response.body
+    assert_select "a[href=?]", show_timetable_path(events(:unpublished).event_key),
+                  text: events(:unpublished).display_name
   end
 
   test "free user cannot access admin dashboard" do

--- a/test/fixtures/event_name_tags.yml
+++ b/test/fixtures/event_name_tags.yml
@@ -18,3 +18,6 @@ six:
 
 no_ai_usage_event:
   name: "AI利用回数0のイベント"
+
+unpublished:
+  name: "非公開イベント"

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -39,3 +39,10 @@ no_ai_usage_event:
   event_key: "no_ai_usage_event"
   description: "AI利用回数0のユーザーのテスト用フェスイベント"
   is_published: true
+
+unpublished:
+  user: one
+  event_name_tag: unpublished
+  event_key: "unpublished"
+  description: "非公開のテスト用フェスイベント"
+  is_published: false

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -11,7 +11,8 @@ one:
   provider: google_oauth2
   uid: "google-uid-12345"
   username: "one"
-  
+  role: free
+
 # テストユーザー2（Googleログイン用）
 two:
   name: User Two
@@ -19,6 +20,7 @@ two:
   provider: google_oauth2
   uid: "google-uid-67890"
   username: "two"
+  role: free
 
 # AI利用上限に達したユーザー
 no_ai_usage:
@@ -27,5 +29,15 @@ no_ai_usage:
   provider: google_oauth2
   uid: "google-uid-11111"
   username: "no_ai_usage"
+  role: free
   ai_timetable_count: 10 # AI利用上限に達している状態を再現
   ai_timetable_reset_at: <%= Date.current %> # AI利用回数がリセットされたのが1ヶ月以内であることを再現
+
+# 開発者ユーザー
+developer:
+  name: Developer User
+  email: developer@example.com
+  provider: google_oauth2
+  uid: "google-uid-developer"
+  username: "developer"
+  role: developer


### PR DESCRIPTION
## Summary
- `role: developer` のアカウントのみが利用できる簡易管理画面（`/admin/dashboard`）を追加
- ユーザー数・一覧（名前・メールアドレス）、タイムテーブル数・一覧（非公開含む）を閲覧可能
- 開発者のみフッターに「管理画面（開発者向け）」リンクを表示。一般ユーザー・未ログインは404またはトップへリダイレクト

Closes #448

## Test plan
- [x] `developer` ロールのアカウントで `/admin/dashboard` にアクセスし、ユーザー・タイムテーブル一覧が表示される
- [x] 一般ユーザーでアクセスした場合、404ページが表示される（例外ページではない）
- [x] 未ログインでアクセスした場合、トップページへリダイレクトされる
- [x] 開発者ログイン時のみフッターに管理画面リンクが表示される
- [x] タイムテーブル名のリンクがタイムテーブルページ（`/t/:event_key`）へ遷移する
- [x] `bin/rails test test/controllers/admin/dashboards_controller_test.rb` が通る


Made with [Cursor](https://cursor.com)