### PR TITLE
feat: タイムテーブルの非公開設定を追加する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -38,8 +38,10 @@ class ApplicationController < ActionController::Base
     # 非公開イベントは作成者本人のみ閲覧を許可する
     def authorize_published_event!(event)
       return if event.is_published?
-      return if user_signed_in? && event.user == current_user
+      return if user_signed_in? && event.user_id == current_user.id
 
-      raise ActiveRecord::RecordNotFound
+      # raise だと開発環境で Exception 画面になるため、公開用404を返す
+      response.set_header("X-Robots-Tag", "noindex, nofollow")
+      render file: Rails.public_path.join("404.html"), status: :not_found, layout: false
     end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -33,4 +33,13 @@ class ApplicationController < ActionController::Base
   end
   # ビューでpreview_environment?メソッドを使用できるようにする
   helper_method :preview_environment?
+
+  private
+    # 非公開イベントは作成者本人のみ閲覧を許可する
+    def authorize_published_event!(event)
+      return if event.is_published?
+      return if user_signed_in? && event.user == current_user
+
+      raise ActiveRecord::RecordNotFound
+    end
 end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -7,6 +7,8 @@ class EventsController < ApplicationController
   before_action :set_event, only: [ :show, :edit, :update, :destroy ]
   # 所有者本人かどうかチェック
   before_action :authorize_event!, only: [ :edit, :update, :destroy ]
+  # 非公開イベントの閲覧制御
+  before_action :authorize_published_event_access!, only: [ :show ]
   # 開催日を昇順で取得
   before_action :set_days, only: [ :show, :edit ]
   before_action :set_page_title, except: %i[ destroy ]
@@ -142,6 +144,11 @@ class EventsController < ApplicationController
   # イベントの所有者かどうかチェック（異なる場合は404エラーを発生させる）
   def authorize_event!
     raise ActiveRecord::RecordNotFound unless @event.user == current_user
+  end
+
+  # 非公開イベントは作成者のみ閲覧可能
+  def authorize_published_event_access!
+    authorize_published_event!(@event)
   end
 
   # 開催日を昇順にセットする

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -180,6 +180,7 @@ class EventsController < ApplicationController
     params.require(:event).permit(
       :description,
       :is_published,
+      :is_private,
       event_name_tag_attributes: [ :name ] # event_name_tagに対するエラーの伝播を許可
     )
   end

--- a/app/controllers/events_controller.rb
+++ b/app/controllers/events_controller.rb
@@ -172,6 +172,7 @@ class EventsController < ApplicationController
   def event_params
     params.require(:event).permit(
       :description,
+      :is_published,
       event_name_tag_attributes: [ :name ] # event_name_tagに対するエラーの伝播を許可
     )
   end

--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -3,6 +3,8 @@ class MyTimetablesController < ApplicationController
   before_action :set_user
   # イベントをセット
   before_action :set_event
+  # 非公開イベントの閲覧制御
+  before_action :authorize_published_event_access!
   # === 出演者、開催日、ステージをセット ===
   before_action :set_performers
   before_action :set_days
@@ -39,6 +41,11 @@ class MyTimetablesController < ApplicationController
     # イベントを取得
     def set_event
       @event = Event.includes(:event_name_tag).find_by!(event_key: params[:event_key])
+    end
+
+    # 非公開イベントは作成者のみ閲覧可能
+    def authorize_published_event_access!
+      authorize_published_event!(@event)
     end
 
     # 出演者を取得

--- a/app/controllers/performers_controller.rb
+++ b/app/controllers/performers_controller.rb
@@ -3,6 +3,8 @@ class PerformersController < ApplicationController
   before_action :set_event
   # indexとshow以外のアクションは所有者本人のみアクセス可能
   before_action :authorize_event!, except: %i[index show]
+  # 非公開イベントの閲覧制御（公開ページ）
+  before_action :authorize_published_event_access!, only: %i[ index show ]
   before_action :set_performer, only: %i[ show edit update destroy ]
   before_action :set_performances, only: %i[ show ]
   before_action :set_page_title, except: %i[ destroy ]
@@ -127,6 +129,11 @@ class PerformersController < ApplicationController
     # イベントの所有者かどうかチェック（異なる場合は404エラーを発生させる）
     def authorize_event!
       raise ActiveRecord::RecordNotFound unless @event.user == current_user
+    end
+
+    # 非公開イベントは作成者のみ閲覧可能
+    def authorize_published_event_access!
+      authorize_published_event!(@event)
     end
 
     # 出演者を取得

--- a/app/controllers/share_controller.rb
+++ b/app/controllers/share_controller.rb
@@ -2,11 +2,13 @@ class ShareController < ApplicationController
   def show
     case params[:type]
     when "event"
-      @event = Event.find_by(event_key: params[:event_key])
+      @event = Event.find_by!(event_key: params[:event_key])
+      authorize_published_event!(@event)
       render layout: false if turbo_frame_request?
     when "my-timetable"
-      @event = Event.find_by(event_key: params[:event_key])
-      @user = User.find_by(username: params[:username])
+      @event = Event.find_by!(event_key: params[:event_key])
+      authorize_published_event!(@event)
+      @user = User.find_by!(username: params[:username])
       render layout: false if turbo_frame_request?
     else
       # 共有URLのtypeパラメータが不正な場合は404 Not Foundを返す

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -3,6 +3,8 @@ class StagesController < ApplicationController
   before_action :set_event
   # indexとshow以外のアクションは所有者本人のみアクセス可能
   before_action :authorize_event!, except: %i[index show]
+  # 非公開イベントの閲覧制御（公開ページ）
+  before_action :authorize_published_event_access!, only: %i[ index show ]
   before_action :set_stage, only: %i[ show edit update destroy ]
   before_action :set_page_title, except: %i[ destroy ]
   before_action :show_event_header, except: %i[ destroy ]
@@ -139,6 +141,11 @@ class StagesController < ApplicationController
     # イベントの所有者かどうかチェック（異なる場合は404エラーを発生させる）
     def authorize_event!
       raise ActiveRecord::RecordNotFound unless @event.user == current_user
+    end
+
+    # 非公開イベントは作成者のみ閲覧可能
+    def authorize_published_event_access!
+      authorize_published_event!(@event)
     end
 
     # ステージを取得

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -3,6 +3,8 @@ class TimetablesController < ApplicationController
   before_action :set_event, only: %i[ show new create ]
   # イベントの所有者本人のみアクセス可能
   before_action :authorize_event!, only: %i[ new create ]
+  # 非公開イベントの閲覧制御
+  before_action :authorize_published_event_access!, only: %i[ show ]
   # === 出演者、開催日、ステージをセット ===
   before_action :set_performers, only: %i[ show ]
   before_action :set_days
@@ -100,6 +102,11 @@ class TimetablesController < ApplicationController
     # イベントの所有者かどうかチェック（異なる場合は404エラーを発生させる）
     def authorize_event!
       raise ActiveRecord::RecordNotFound unless @event.user == current_user
+    end
+
+    # 非公開イベントは作成者のみ閲覧可能
+    def authorize_published_event_access!
+      authorize_published_event!(@event)
     end
 
     # 出演者を取得

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -4,17 +4,18 @@ module EventsHelper
     content_tag(
       :span,
       "lock",
-      class: "material-symbols-outlined",
+      class: "material-symbols-outlined leading-none",
       style: "font-size: 1rem;"
     )
   end
 
   # 非公開時は左端に鍵アイコンを付けたタイムテーブル名を返す
   def event_name_with_lock(event)
-    parts = []
-    parts << lock_icon unless event.is_published?
-    parts << event.display_name
-    content_tag(:span, safe_join(parts, " "), class: "inline-flex items-center gap-1")
+    return event.display_name if event.is_published?
+
+    content_tag(:span, class: "inline-flex items-center gap-1 align-middle leading-none") do
+      safe_join([ lock_icon, event.display_name ], " ")
+    end
   end
 
   # event-headerの色のクラスを返す

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,4 +1,22 @@
 module EventsHelper
+  # 非公開タイムテーブル用の鍵アイコン
+  def lock_icon
+    content_tag(
+      :span,
+      "lock",
+      class: "material-symbols-outlined",
+      style: "font-size: 1rem;"
+    )
+  end
+
+  # 非公開時は左端に鍵アイコンを付けたタイムテーブル名を返す
+  def event_name_with_lock(event)
+    parts = []
+    parts << lock_icon unless event.is_published?
+    parts << event.display_name
+    content_tag(:span, safe_join(parts, " "), class: "inline-flex items-center gap-1")
+  end
+
   # event-headerの色のクラスを返す
   def event_header_color
     @my_timetable_view ? "bg-orange-600" : "bg-gray-800"
@@ -7,9 +25,9 @@ module EventsHelper
   # event-headerのタイトルを返す
   def event_header_title
     if @my_timetable_view
-      "#{@user.name}の#{@event.display_name} マイタイムテーブル"
+      safe_join([ "#{@user.name}の", event_name_with_lock(@event), " マイタイムテーブル" ])
     else
-      "#{@event.display_name}"
+      event_name_with_lock(@event)
     end
   end
 

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -29,7 +29,8 @@ class Event < ApplicationRecord
   # みんなが作ったタイムテーブルのうち、未来イベントを取得
   scope :future_all, -> {
     now = Time.current.to_date
-    left_joins(:event_favorites)
+    where(is_published: true)
+      .left_joins(:event_favorites)
       .left_joins(performers: :performances)
       .left_joins(:days)
       .includes(:user, :days)
@@ -47,7 +48,8 @@ class Event < ApplicationRecord
   # みんなが作ったタイムテーブルのうち、過去イベントを取得
   scope :past_all, -> {
     now = Time.current.to_date
-    left_joins(:event_favorites)
+    where(is_published: true)
+      .left_joins(:event_favorites)
       .left_joins(performers: :performances)
       .left_joins(:days)
       .includes(:user, :days)

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -82,9 +82,11 @@ class Event < ApplicationRecord
   }
 
   # お気に入りタイムテーブル（最後にお気に入りした順）
+  # 非公開イベントは作成者本人のお気に入り一覧にのみ表示する
   scope :recent_favorite_by, ->(user) {
     joins(:event_favorites)
       .where(event_favorites: { user_id: user.id })
+      .where("events.is_published = ? OR events.user_id = ?", true, user.id)
       .includes(:user, :days)
       .order("event_favorites.created_at DESC")
   }

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -98,4 +98,14 @@ class Event < ApplicationRecord
   def display_name
     event_name_tag.name
   end
+
+  # フォーム用: 非公開チェックボックス（オン=非公開）
+  # boolean列 is_published を反転した値として扱う
+  def is_private
+    !is_published?
+  end
+
+  def is_private=(value)
+    self.is_published = !ActiveModel::Type::Boolean.new.cast(value)
+  end
 end

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -3,7 +3,7 @@
                           class: "block bg-white shadow-md rounded-lg p-4 border hover:shadow-xl hover:bg-gray-50 transition" do %>
   <%# タイトル %>
   <p class="text-lg font-semibold text-gray-800 line-clamp-1">
-    <%= event.display_name %>
+    <%= event_name_with_lock(event) %>
   </p>
   <%# 開催日 %>
   <p class="text-sm text-gray-500">

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -38,7 +38,7 @@
           <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800" %>
           <span class="text-sm text-gray-800">公開する</span>
         </label>
-        <p class="mt-1 text-xs text-gray-500">オフにすると、みんなの一覧には表示されません。</p>
+        <p class="mt-1 text-xs text-gray-500">オフにすると、自分以外は閲覧できません。</p>
       </div>
       <%# 作成ボタン %>
       <div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -38,7 +38,7 @@
           <%= f.check_box :is_private, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" %>
           <span class="text-sm text-gray-800">非公開にする</span>
         </label>
-        <p class="mt-1 text-xs text-gray-500">非公開にすると自分以外は閲覧できません。</p>
+        <p class="mt-1 text-xs text-gray-500">オンにすると自分だけに表示されます。</p>
       </div>
       <%# 作成ボタン %>
       <div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -35,7 +35,7 @@
       <%# 公開設定トグル %>
       <div>
         <label class="inline-flex items-center gap-2 cursor-pointer">
-          <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800" %>
+          <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" %>
           <span class="text-sm text-gray-800">公開する</span>
         </label>
         <p class="mt-1 text-xs text-gray-500">オフにすると、自分以外は閲覧できません。</p>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -32,6 +32,14 @@
           class: "w-full border border-gray-300 rounded-md px-3 py-2 text-gray-800
                   focus:outline-none focus:ring-1 focus:ring-gray-800 focus:border-gray-800 min-h-32 resize-y overflow-y-auto"%>
       </div>
+      <%# 公開設定トグル %>
+      <div>
+        <label class="inline-flex items-center gap-2 cursor-pointer">
+          <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800" %>
+          <span class="text-sm text-gray-800">公開する</span>
+        </label>
+        <p class="mt-1 text-xs text-gray-500">オフにすると、みんなの一覧には表示されません。</p>
+      </div>
       <%# 作成ボタン %>
       <div>
         <%= f.submit "更新",

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -32,13 +32,15 @@
           class: "w-full border border-gray-300 rounded-md px-3 py-2 text-gray-800
                   focus:outline-none focus:ring-1 focus:ring-gray-800 focus:border-gray-800 min-h-32 resize-y overflow-y-auto"%>
       </div>
-      <%# 公開設定トグル %>
+      <%# 非公開設定トグル（オンで非公開） %>
       <div>
         <label class="inline-flex items-center gap-2 cursor-pointer">
-          <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" %>
-          <span class="text-sm text-gray-800">公開する</span>
+          <%= f.check_box :is_published,
+                { class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" },
+                "0", "1" %>
+          <span class="text-sm text-gray-800">非公開にする</span>
         </label>
-        <p class="mt-1 text-xs text-gray-500">オフにすると、自分以外は閲覧できません。</p>
+        <p class="mt-1 text-xs text-gray-500">非公開にすると自分以外は閲覧できません。</p>
       </div>
       <%# 作成ボタン %>
       <div>

--- a/app/views/events/edit.html.erb
+++ b/app/views/events/edit.html.erb
@@ -35,9 +35,7 @@
       <%# 非公開設定トグル（オンで非公開） %>
       <div>
         <label class="inline-flex items-center gap-2 cursor-pointer">
-          <%= f.check_box :is_published,
-                { class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" },
-                "0", "1" %>
+          <%= f.check_box :is_private, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" %>
           <span class="text-sm text-gray-800">非公開にする</span>
         </label>
         <p class="mt-1 text-xs text-gray-500">非公開にすると自分以外は閲覧できません。</p>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -37,7 +37,7 @@
         <%= f.check_box :is_private, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" %>
         <span class="text-sm text-gray-800">非公開にする</span>
       </label>
-      <p class="mt-1 text-xs text-gray-500">非公開にすると自分以外は閲覧できません。</p>
+      <p class="mt-1 text-xs text-gray-500">オンにすると自分だけに表示されます。</p>
     </div>
     <%# 作成ボタン %>
     <div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -34,9 +34,7 @@
     <%# 非公開設定トグル（オンで非公開） %>
     <div>
       <label class="inline-flex items-center gap-2 cursor-pointer">
-        <%= f.check_box :is_published,
-              { class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" },
-              "0", "1" %>
+        <%= f.check_box :is_private, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" %>
         <span class="text-sm text-gray-800">非公開にする</span>
       </label>
       <p class="mt-1 text-xs text-gray-500">非公開にすると自分以外は閲覧できません。</p>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -31,6 +31,14 @@
         class: "w-full border border-gray-300 rounded-md px-3 py-2 text-gray-800
                 focus:outline-none focus:ring-1 focus:ring-gray-800 focus:border-gray-800 min-h-32 resize-y overflow-y-auto"%>
     </div>
+    <%# 公開設定トグル %>
+    <div>
+      <label class="inline-flex items-center gap-2 cursor-pointer">
+        <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800" %>
+        <span class="text-sm text-gray-800">公開する</span>
+      </label>
+      <p class="mt-1 text-xs text-gray-500">オフにすると、みんなの一覧には表示されません。</p>
+    </div>
     <%# 作成ボタン %>
     <div>
       <%= f.submit "作成",

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -37,7 +37,7 @@
         <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800" %>
         <span class="text-sm text-gray-800">公開する</span>
       </label>
-      <p class="mt-1 text-xs text-gray-500">オフにすると、みんなの一覧には表示されません。</p>
+      <p class="mt-1 text-xs text-gray-500">オフにすると、自分以外は閲覧できません。</p>
     </div>
     <%# 作成ボタン %>
     <div>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -34,7 +34,7 @@
     <%# 公開設定トグル %>
     <div>
       <label class="inline-flex items-center gap-2 cursor-pointer">
-        <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800" %>
+        <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" %>
         <span class="text-sm text-gray-800">公開する</span>
       </label>
       <p class="mt-1 text-xs text-gray-500">オフにすると、自分以外は閲覧できません。</p>

--- a/app/views/events/new.html.erb
+++ b/app/views/events/new.html.erb
@@ -31,13 +31,15 @@
         class: "w-full border border-gray-300 rounded-md px-3 py-2 text-gray-800
                 focus:outline-none focus:ring-1 focus:ring-gray-800 focus:border-gray-800 min-h-32 resize-y overflow-y-auto"%>
     </div>
-    <%# 公開設定トグル %>
+    <%# 非公開設定トグル（オンで非公開） %>
     <div>
       <label class="inline-flex items-center gap-2 cursor-pointer">
-        <%= f.check_box :is_published, class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" %>
-        <span class="text-sm text-gray-800">公開する</span>
+        <%= f.check_box :is_published,
+              { class: "w-4 h-4 text-gray-800 border-gray-300 rounded focus:ring-gray-800 cursor-pointer" },
+              "0", "1" %>
+        <span class="text-sm text-gray-800">非公開にする</span>
       </label>
-      <p class="mt-1 text-xs text-gray-500">オフにすると、自分以外は閲覧できません。</p>
+      <p class="mt-1 text-xs text-gray-500">非公開にすると自分以外は閲覧できません。</p>
     </div>
     <%# 作成ボタン %>
     <div>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -12,7 +12,7 @@
     <% end %>
     <%# タイトル %>
     <h1 class="text-xl font-bold text-gray-800 mb-2">
-      <%= @event.event_name_tag.name %>
+      <%= event_name_with_lock(@event) %>
     </h1>
     <%# お気に入り数 %>
     <p class="mb-2 text-sm flex justify-start items-center">

--- a/app/views/layouts/_event-header.html.erb
+++ b/app/views/layouts/_event-header.html.erb
@@ -5,7 +5,7 @@
     <div class="flex-1">
       <%= render "events/favorite_button", event: @event %>
     </div>
-    <h1 class="text-sm text-white truncate text-center flex-none max-w-[95%]">
+    <h1 class="text-sm text-white truncate text-center flex-none max-w-[95%] flex items-center justify-center leading-none">
       <%= event_header_title %>
     </h1>
     <%# 共有ボタン（data-urlで読み込ませたいURLを指定する） %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,8 @@
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%# ステージング環境では検索エンジンにインデックスさせないための設定 %>
-    <% if Rails.env.staging? %>
+    <%# ステージング環境、または非公開タイムテーブルでは検索エンジンにインデックスさせない %>
+    <% if Rails.env.staging? || (@event.present? && !@event.is_published?) %>
       <meta name="robots" content="noindex, nofollow">
     <% end %>
     <%# OGP画像 %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -34,7 +34,7 @@
     <link rel="apple-touch-icon" href="/icon.png?v=2">
     <%# Googleアイコン読み込み%>
     <link rel="stylesheet" 
-          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=add,add_location,arrow_back,arrow_forward_ios,artist,calendar_add_on,check,close,content_copy,drag_handle,edit,edit_calendar,event,favorite,info,ios_share,list,login,map,moved_location,music_note_2,open_in_new,person,person_add,table,upload,wand_stars" />
+          href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200&icon_names=add,add_location,arrow_back,arrow_forward_ios,artist,calendar_add_on,check,close,content_copy,drag_handle,edit,edit_calendar,event,favorite,info,ios_share,list,lock,login,map,moved_location,music_note_2,open_in_new,person,person_add,table,upload,wand_stars" />
     <%# Googleフォント読み込み%>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -154,6 +154,19 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should check private checkbox when event is unpublished" do
+    unpublished_event = events(:unpublished)
+    get edit_event_url(unpublished_event.event_key)
+    assert_response :success
+    assert_select "input[name='event[is_private]'][type=checkbox][checked]"
+  end
+
+  test "should not check private checkbox when event is published" do
+    get edit_event_url(@event.event_key)
+    assert_response :success
+    assert_select "input[name='event[is_private]'][type=checkbox][checked]", count: 0
+  end
+
   # 他者が作成した編集フォームは表示できない
   test "should not get edit form of other user's event" do
     get edit_event_url(@other_event.event_key)

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -22,6 +22,19 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should not show unpublished event with logout" do
+    sign_out @user
+    get event_url(events(:unpublished).event_key)
+    assert_response :not_found
+  end
+
+  test "should not show unpublished event by other user" do
+    sign_out @user
+    sign_in users(:two)
+    get event_url(events(:unpublished).event_key)
+    assert_response :not_found
+  end
+
   # 他者が作成したイベント詳細も表示できる
   test "should show event by other user" do
     get event_url(@other_event.event_key)

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -41,10 +41,23 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should show lock icon on unpublished event detail for owner" do
+    unpublished_event = events(:unpublished)
+    get event_url(unpublished_event.event_key)
+    assert_response :success
+    assert_select "span.material-symbols-outlined", text: "lock"
+  end
+
   # 自分が作成したイベント一覧
   test "should index" do
     get events_path
     assert_response :success
+  end
+
+  test "should show lock icon for unpublished event in created list" do
+    get events_path(filter: "created")
+    assert_response :success
+    assert_select "span.material-symbols-outlined", text: "lock"
   end
 
   # イベント作成ページを表示

--- a/test/controllers/events_controller_test.rb
+++ b/test/controllers/events_controller_test.rb
@@ -66,6 +66,22 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to show_timetable_path(created_event.event_key)
   end
 
+  test "should create unpublished event" do
+    event_name = "非公開イベント作成テスト"
+    assert_difference("Event.count", 1) do
+      post events_url, params: {
+        event: {
+          event_name_tag_attributes: { name: event_name },
+          description: "説明",
+          is_published: false
+        }
+      }
+    end
+
+    created_event = Event.last
+    assert_not created_event.is_published?
+  end
+
   # 1ユーザー内のイベント名が重複する場合は作成できない
   test "should not create overlapping event" do
     overlapping_event_name = "Event1"
@@ -138,6 +154,20 @@ class EventsControllerTest < ActionDispatch::IntegrationTest
 
     # Event 本体の値も更新されていること
     assert_equal "説明更新", @event.description
+  end
+
+  test "should update event publication status" do
+    patch event_url(@event.event_key), params: {
+      event: {
+        description: @event.description,
+        is_published: false,
+        event_name_tag_attributes: { name: @event.event_name_tag.name }
+      }
+    }
+
+    assert_redirected_to event_path(@event.event_key)
+    @event.reload
+    assert_not @event.is_published?
   end
 
   # イベント名が空文字の場合は編集できない

--- a/test/controllers/my_timetables_controller_test.rb
+++ b/test/controllers/my_timetables_controller_test.rb
@@ -32,4 +32,19 @@ class MyTimetablesControllerTest < ActionDispatch::IntegrationTest
     get show_my_timetable_path(event_key: @event.event_key, username: @user.username)
     assert_response :success
   end
+
+  test "should not get unpublished my_timetable with logout" do
+    sign_out @user
+    unpublished_event = events(:unpublished)
+    get show_my_timetable_path(event_key: unpublished_event.event_key, username: @user.username)
+    assert_response :not_found
+  end
+
+  test "should not get unpublished my_timetable by other user" do
+    sign_out @user
+    sign_in @user_two
+    unpublished_event = events(:unpublished)
+    get show_my_timetable_path(event_key: unpublished_event.event_key, username: @user.username)
+    assert_response :not_found
+  end
 end

--- a/test/controllers/performers_controller_test.rb
+++ b/test/controllers/performers_controller_test.rb
@@ -30,6 +30,19 @@ class PerformersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should not get unpublished event performers with logout" do
+    sign_out @user
+    get event_performers_url(events(:unpublished).event_key)
+    assert_response :not_found
+  end
+
+  test "should not get unpublished event performers by other user" do
+    sign_out @user
+    sign_in users(:two)
+    get event_performers_url(events(:unpublished).event_key)
+    assert_response :not_found
+  end
+
   # 出演者詳細
   test "should get show" do
     performer = @event.performers.first

--- a/test/controllers/share_controller_test.rb
+++ b/test/controllers/share_controller_test.rb
@@ -1,4 +1,27 @@
 require "test_helper"
 
 class ShareControllerTest < ActionDispatch::IntegrationTest
+  include Devise::Test::IntegrationHelpers
+
+  setup do
+    @user = users(:one)
+    @user_two = users(:two)
+    @unpublished_event = events(:unpublished)
+  end
+
+  test "should return 404 for unpublished event share with logout" do
+    get share_path(type: "event", event_key: @unpublished_event.event_key)
+    assert_response :not_found
+  end
+
+  test "should return 404 for unpublished event share by other user" do
+    sign_in @user_two
+    get share_path(type: "event", event_key: @unpublished_event.event_key)
+    assert_response :not_found
+  end
+
+  test "should return 404 for unpublished my timetable share with logout" do
+    get share_path(type: "my-timetable", event_key: @unpublished_event.event_key, username: @user.username)
+    assert_response :not_found
+  end
 end

--- a/test/controllers/stages_controller_test.rb
+++ b/test/controllers/stages_controller_test.rb
@@ -30,6 +30,19 @@ class StagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should not get unpublished event stages with logout" do
+    sign_out @user
+    get event_stages_url(events(:unpublished).event_key)
+    assert_response :not_found
+  end
+
+  test "should not get unpublished event stages by other user" do
+    sign_out @user
+    sign_in users(:two)
+    get event_stages_url(events(:unpublished).event_key)
+    assert_response :not_found
+  end
+
   # ステージ詳細
   test "should get show stage" do
     stage = @event.stages.first

--- a/test/controllers/timetables_controller_test.rb
+++ b/test/controllers/timetables_controller_test.rb
@@ -38,6 +38,7 @@ class TimetablesControllerTest < ActionDispatch::IntegrationTest
     sign_out @user
     get show_timetable_path(events(:unpublished).event_key)
     assert_response :not_found
+    assert_includes response.body, "ページが見つかりません"
   end
 
   test "should not get unpublished timetable by other user" do
@@ -45,6 +46,7 @@ class TimetablesControllerTest < ActionDispatch::IntegrationTest
     sign_in @user_two
     get show_timetable_path(events(:unpublished).event_key)
     assert_response :not_found
+    assert_includes response.body, "ページが見つかりません"
   end
 
   # デフォルト（最古日付）での表示テスト

--- a/test/controllers/timetables_controller_test.rb
+++ b/test/controllers/timetables_controller_test.rb
@@ -34,6 +34,19 @@ class TimetablesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "should not get unpublished timetable with logout" do
+    sign_out @user
+    get show_timetable_path(events(:unpublished).event_key)
+    assert_response :not_found
+  end
+
+  test "should not get unpublished timetable by other user" do
+    sign_out @user
+    sign_in @user_two
+    get show_timetable_path(events(:unpublished).event_key)
+    assert_response :not_found
+  end
+
   # デフォルト（最古日付）での表示テスト
   test "should show event timetable by event_key" do
     get show_timetable_path(@event.event_key)

--- a/test/fixtures/event_favorites.yml
+++ b/test/fixtures/event_favorites.yml
@@ -1,3 +1,11 @@
 user_one_to_event_one:
   user: one
   event: one
+
+user_two_to_unpublished:
+  user: two
+  event: unpublished
+
+user_one_to_unpublished:
+  user: one
+  event: unpublished

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -22,4 +22,14 @@ class EventTest < ActiveSupport::TestCase
     assert event.is_published?
     assert_not event.is_private
   end
+
+  test "recent_favorite_by excludes unpublished events for other users" do
+    favorites = Event.recent_favorite_by(users(:two))
+    assert_not_includes favorites, events(:unpublished)
+  end
+
+  test "recent_favorite_by includes unpublished events for owner" do
+    favorites = Event.recent_favorite_by(users(:one))
+    assert_includes favorites, events(:unpublished)
+  end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -8,4 +8,18 @@ class EventTest < ActiveSupport::TestCase
   test "past_all excludes unpublished events" do
     assert_not_includes Event.past_all, events(:unpublished)
   end
+
+  test "is_private mirrors inverted is_published" do
+    event = events(:one)
+    assert event.is_published?
+    assert_not event.is_private
+
+    event.is_private = true
+    assert_not event.is_published?
+    assert event.is_private
+
+    event.is_private = false
+    assert event.is_published?
+    assert_not event.is_private
+  end
 end

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,7 +1,11 @@
 require "test_helper"
 
 class EventTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
+  test "future_all excludes unpublished events" do
+    assert_not_includes Event.future_all, events(:unpublished)
+  end
+
+  test "past_all excludes unpublished events" do
+    assert_not_includes Event.past_all, events(:unpublished)
+  end
 end


### PR DESCRIPTION
## Summary
- Closes #144
- タイムテーブルをデフォルト公開のまま、任意で非公開にできるようにする
- 非公開時は作成者本人以外（未ログイン含む）は閲覧不可（404）
- 一覧・個別表示で非公開タイムテーブル名の左端に鍵アイコンを表示する

## 変更内容
- 新規作成 / 編集フォームの説明欄下に「非公開にする」チェックボックスを追加
  - オフ（デフォルト）: 公開
  - オン: 非公開
- フォーム用に `Event#is_private` 仮想属性を追加（内部は既存の `is_published` を反転）
- 公開一覧（トップ / みんなが作ったタイムテーブル）は `is_published: true` のみ表示
- 非公開の閲覧制御を以下に適用
  - 概要（`events#show`）
  - タイムテーブル（`timetables#show`）
  - マイタイムテーブル（`my_timetables#show`）
  - 共有モーダル（`share#show`）
  - ステージ一覧・詳細（`stages#index/show`）
  - 出演者一覧・詳細（`performers#index/show`）
- Material Symbols の `icon_names` に `lock` を追加

## 非公開設定方法
1. タイムテーブル新規作成、または編集ページを開く
2. 説明欄の下にある「非公開にする」をオンにする
3. 作成 / 更新する
4. 補足文言: 「オンにすると自分だけに表示されます。」

作成者本人の「作成したタイムテーブル一覧」には非公開も表示されます（鍵アイコン付き）。

## Test plan
- [x] 新規作成で「非公開にする」オフのまま作成 → 公開として一覧に出る
- [x] 新規作成で「非公開にする」オンで作成 → 他人・未ログインは404、本人は閲覧可
- [x] 編集で公開 ↔ 非公開を切り替えできる
- [x] 編集画面を開いたとき、非公開ならチェックオン / 公開ならチェックオフ
- [x] 非公開イベントのタイムテーブルURL / 概要URL / マイタイムテーブルURL / 共有モーダルが他人・未ログインで404
- [x] 非公開イベントのステージ一覧・出演者一覧も他人・未ログインで404
- [x] 作成したタイムテーブル一覧で非公開名の左端に鍵アイコンが出る
- [x] 概要ページ・イベントヘッダーでも非公開時に鍵アイコンが出る
- [x] 自動テスト: `bundle exec rails test test/controllers/events_controller_test.rb test/controllers/timetables_controller_test.rb test/controllers/my_timetables_controller_test.rb test/controllers/share_controller_test.rb test/controllers/stages_controller_test.rb test/controllers/performers_controller_test.rb test/models/event_test.rb`

## 注意点
- DBカラムは既存の `is_published`（デフォルト `true`）を継続利用。マイグレーション追加なし
- 「作成したタイムテーブル」「お気に入り」一覧は本人向けのため、非公開イベントも表示され得る。他人がお気に入り済みのイベントを後から非公開にした場合、一覧には残っても詳細URLは404になる
- 管理画面では従来どおり非公開を含む全件を確認できる
- ブランチ名は作業経緯で `feat/448-developer-admin` 上に積んでいたが、PR対象は非公開機能のみ（管理画面は #449 でマージ済み）


Made with [Cursor](https://cursor.com)