### PR TITLE
fix: bulletが検出したN+1問題を解消する

### DIFF
--- a/app/controllers/my_timetables_controller.rb
+++ b/app/controllers/my_timetables_controller.rb
@@ -40,7 +40,7 @@ class MyTimetablesController < ApplicationController
 
     # イベントを取得
     def set_event
-      @event = Event.includes(:event_name_tag).find_by!(event_key: params[:event_key])
+      @event = Event.find_by!(event_key: params[:event_key])
     end
 
     # 非公開イベントは作成者のみ閲覧可能

--- a/app/controllers/performances_controller.rb
+++ b/app/controllers/performances_controller.rb
@@ -94,7 +94,7 @@ class PerformancesController < ApplicationController
 
     # 出演者を取得
     def set_performers
-      @performers = @event.performers.order_by_name
+      @performers = @event.performers.order_by_name.includes(:performer_name_tag)
     end
 
     # 開催日を取得
@@ -104,7 +104,7 @@ class PerformancesController < ApplicationController
 
     # ステージを取得
     def set_stages
-      @stages = @event.stages
+      @stages = @event.stages.includes(:stage_name_tag)
     end
 
     # ページタイトルを設定

--- a/app/controllers/performers_controller.rb
+++ b/app/controllers/performers_controller.rb
@@ -11,7 +11,9 @@ class PerformersController < ApplicationController
   before_action :show_event_header, except: %i[ destroy ]
 
   def index
-    @performers = @event.performers.order_by_name.includes(:performances)
+    @performers = @event.performers
+                        .order_by_name
+                        .includes(:performer_name_tag, performances: [ :day, { stage: :stage_name_tag } ])
     # お気に入り登録している出演者IDの配列を取得
     if user_signed_in?
       @favorite_performer_map = current_user.favorite_performer_map
@@ -32,7 +34,7 @@ class PerformersController < ApplicationController
   end
 
   def create
-    @performers = @event.performers
+    @performers = @event.performers.includes(:performer_name_tag)
     @performer = @event.performers.build(performer_params)
 
     # フォームで受け取るタグ名（fields_for で post される形）

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -11,7 +11,7 @@ class StagesController < ApplicationController
 
   # ステージ一覧
   def index
-    @stages = @event.stages.order(:position)
+    @stages = @event.stages.order(:position).includes(:stage_name_tag)
   end
 
   # ステージ
@@ -26,7 +26,7 @@ class StagesController < ApplicationController
 
   # ステージ作成処理
   def create
-    @stages = @event.stages.order(:position)
+    @stages = @event.stages.order(:position).includes(:stage_name_tag)
     @stage = @event.stages.build(stage_params)
 
     # フォームで受け取るタグ名（fields_for で post される形）
@@ -119,7 +119,7 @@ class StagesController < ApplicationController
 
   # ステージ並び替えページ
   def sort
-    @stages = @event.stages.order(:position)
+    @stages = @event.stages.order(:position).includes(:stage_name_tag)
   end
 
   # ステージ並び替え処理

--- a/app/controllers/timetables_controller.rb
+++ b/app/controllers/timetables_controller.rb
@@ -96,7 +96,7 @@ class TimetablesController < ApplicationController
         else
           params[:event_event_key]
         end
-      @event = Event.includes(:event_name_tag).find_by!(event_key: event_key_param)
+      @event = Event.find_by!(event_key: event_key_param)
     end
 
     # イベントの所有者かどうかチェック（異なる場合は404エラーを発生させる）

--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -33,7 +33,7 @@ class Event < ApplicationRecord
       .left_joins(:event_favorites)
       .left_joins(performers: :performances)
       .left_joins(:days)
-      .includes(:user, :days)
+      .includes(:user, :days, :event_name_tag, :event_favorites)
       .group(:id)
       .having("MAX(days.date) >= ?", now)
       .order(
@@ -52,7 +52,7 @@ class Event < ApplicationRecord
       .left_joins(:event_favorites)
       .left_joins(performers: :performances)
       .left_joins(:days)
-      .includes(:user, :days)
+      .includes(:user, :days, :event_name_tag, :event_favorites)
       .group(:id)
       .having("MAX(days.date) < ?", now)
       .order(
@@ -72,7 +72,7 @@ class Event < ApplicationRecord
   # 作成したタイムテーブル
   scope :recent_created_by, ->(user) {
     where(user: user)
-      .includes(:user, :days)
+      .includes(:user, :days, :event_name_tag, :event_favorites)
       .order(created_at: :desc)
   }
 
@@ -87,7 +87,7 @@ class Event < ApplicationRecord
     joins(:event_favorites)
       .where(event_favorites: { user_id: user.id })
       .where("events.is_published = ? OR events.user_id = ?", true, user.id)
-      .includes(:user, :days)
+      .includes(:user, :days, :event_name_tag, :event_favorites)
       .order("event_favorites.created_at DESC")
   }
 

--- a/app/models/performance.rb
+++ b/app/models/performance.rb
@@ -31,7 +31,7 @@ class Performance < ApplicationRecord
   # 開催日と開始時刻順で並べ、必要な関連も事前ロードするスコープ
   scope :ordered_for_performer_detail, -> {
     left_joins(:day)
-      .includes(:day, :stage)
+      .includes(:day, stage: :stage_name_tag)
       .order(
         Arel.sql("days.date IS NULL ASC"), # dayあり → dayなし の順
         "days.date ASC",
@@ -49,10 +49,7 @@ class Performance < ApplicationRecord
     )
     .where(performers: { event_id: event.id })
     .where(days: { date: date })
-    .includes(
-      performer: :performer_name_tag,
-      stage: :stage_name_tag
-    )
+    .includes(performer: :performer_name_tag)
     .order(:start_time)
   }
 

--- a/app/views/events/_event.html.erb
+++ b/app/views/events/_event.html.erb
@@ -27,7 +27,7 @@
                       style="font-size: 1rem;">
         favorite
       </span>
-      <%= event.event_favorites.size %>
+      <%= event.event_favorites.length %>
     </p>
   </div>
 <% end %>

--- a/app/views/performers/index.html.erb
+++ b/app/views/performers/index.html.erb
@@ -20,7 +20,7 @@
           <%# 名前 %>
           <p class="mb-2 text-lg font-semibold text-gray-800 line-clamp-2"><%= performer.display_name %></p>
           <%# 出演情報 %>
-          <% if performer.performances.exists? %>
+          <% if performer.performances.any? %>
             <div class="gap-1 flex flex-col text-gray-500">
               <div class="gap-1 flex items-baseline">
                 <% performance = performer.performances.first %>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -80,5 +80,14 @@ Rails.application.configure do
   config.after_initialize do
     Bullet.enable = true
     Bullet.rails_logger = true
+
+    # `dependent: :destroy` のカスケード削除はActive Recordが関連を1件ずつ読み込むため
+    # N+1として検出されるが、削除時のコールバックを動かす以上避けられないので除外する
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Event", association: :days
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Event", association: :stages
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Event", association: :performers
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Event", association: :event_favorites
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Performer", association: :performances
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Performance", association: :performance_favorites
   end
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -51,11 +51,19 @@ Rails.application.configure do
   # Raise error when a before_action's only/except options reference missing actions.
   config.action_controller.raise_on_missing_callback_actions = true
 
-  # N+1クエリを検出してRailsログに警告を出力する
-  # 既存のN+1を解消するまでは raise させず、ログ出力のみに留める
+  # N+1クエリを検出してRailsログに警告を出力し、検出時はテストを失敗させる
   config.after_initialize do
     Bullet.enable = true
     Bullet.rails_logger = true
-    Bullet.raise = false
+    Bullet.raise = true
+
+    # `dependent: :destroy` のカスケード削除はActive Recordが関連を1件ずつ読み込むため
+    # N+1として検出されるが、削除時のコールバックを動かす以上避けられないので除外する
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Event", association: :days
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Event", association: :stages
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Event", association: :performers
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Event", association: :event_favorites
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Performer", association: :performances
+    Bullet.add_safelist type: :n_plus_one_query, class_name: "Performance", association: :performance_favorites
   end
 end


### PR DESCRIPTION
close #451

## 概要

#365 で導入したbulletが検出したN+1問題をすべて解消し、test環境の `Bullet.raise` を有効にしました。

警告は13件（加えてカウンターキャッシュの警告6件）から0件になり、`Bullet.raise = true` の状態で全180テストがパスします。

## 効果

`main` と同じテストを並列なしで実行し、リクエストごとの発行クエリ数を比較しました。

| ページ | before | after |
| --- | --- | --- |
| 出演者一覧 `/events/:event_key/performers` | 33 | 12 |
| ステージ一覧 `/events/:event_key/stages` | 15 | 10 |
| トップ `/` | 12 | 6 |
| みんなが作ったタイムテーブル `/events` | 12 | 6 |
| 作成したタイムテーブル `/events?filter=created` | 12 | 6 |
| ステージ並び替え `/events/:event_key/stages/sort` | 11 | 7 |
| タイムテーブル `/t/:event_key` | 14 | 12 |

テストのフィクスチャは数件しかないため、実データではさらに差が開きます。

## 変更内容

### 先読みの追加

- `Event` の4つのスコープ（`future_all` / `past_all` / `recent_created_by` / `recent_favorite_by`）に `event_name_tag` と `event_favorites` を追加。イベント一覧のカードがタイムテーブル名とお気に入り数を表示するため
- `PerformersController#index` に `performer_name_tag` と `performances: [:day, { stage: :stage_name_tag }]` を追加。出演者一覧は出演情報の開催日とステージ名まで表示するため
- ステージ名・出演者名を表示する各アクション（`StagesController` の `index` / `create` / `sort`、`PerformancesController` の `set_performers` / `set_stages`、`PerformersController#create`）に `includes` を追加
- `Performance.ordered_for_performer_detail` の `:stage` を `stage: :stage_name_tag` に変更。出演者詳細でステージ名を表示するため

### 不要な先読みの削除

- `TimetablesController#set_event` / `MyTimetablesController#set_event` の `Event.includes(:event_name_tag)` を削除。単一レコードの `find_by!` なので先読みしてもクエリ数は変わらず、非公開イベントで404になる経路では完全に無駄になっていた
- `Performance.timetable_ready_for_event_on_date` から `stage: :stage_name_tag` を削除。タイムテーブル画面はステージ名を `@stages` 側から取得しており `performance.stage` を参照しないため

### ビューの修正

- `app/views/performers/index.html.erb` の `performer.performances.exists?` を `any?` に変更。`exists?` は先読みしても出演者1件ごとにSQLを発行するため
- `app/views/events/_event.html.erb` の `event.event_favorites.size` を `length` に変更。`size` は先読み済み配列があってもbulletが「参照した」と認識せず、未使用の先読みとして警告が残るため

どちらも表示結果は変わりません。

### bulletの設定

- `dependent: :destroy` のカスケード削除（アカウント削除、タイムテーブル削除、AI作成時の出演情報の洗い替え）で発生する6種類の検出を `Bullet.add_safelist` で除外。削除コールバックを動かす以上、Active Recordが関連を1件ずつ読み込むのは避けられないため
- test環境の `Bullet.raise` を `true` に変更。今後CIでN+1をブロックする

## 補足

Issue #451 に記載できていませんでしたが、`Need Counter Cache`（`Event => [:event_favorites]`、6件）という別種の警告も出ていました。イベント一覧のお気に入り数表示が原因で、こちらもあわせて解消しています。カウンターキャッシュ列の追加ではなく `includes` で対応したため、マイグレーションは不要です。

## 動作確認

- [x] `bin/rails test` : 180 runs, 456 assertions, 0 failures, 0 errors（`Bullet.raise = true` の状態）
- [x] `log/test.log` にbulletの警告が1件も出ないことを確認
- [x] `bin/rubocop` : 148ファイル、違反なし
- [x] `bin/brakeman` : Security Warnings 0

Made with [Cursor](https://cursor.com)