### PR TITLE
feat: 名前が未確認のユーザーがページを表示したときに、名前変更モーダルを自動で表示する

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,6 +34,12 @@ class ApplicationController < ActionController::Base
   # ビューでpreview_environment?メソッドを使用できるようにする
   helper_method :preview_environment?
 
+  # 名前変更モーダルを表示するかどうかを判定するヘルパーメソッド
+  def show_name_confirmation_modal?
+    user_signed_in? && !current_user.name_confirmed?
+  end
+  helper_method :show_name_confirmation_modal?
+
   private
     # 非公開イベントは作成者本人のみ閲覧を許可する
     def authorize_published_event!(event)

--- a/app/controllers/name_confirmations_controller.rb
+++ b/app/controllers/name_confirmations_controller.rb
@@ -14,9 +14,8 @@ class NameConfirmationsController < ApplicationController
 
   def update
     @user = current_user
-    # 「名前を変更する」を押した場合のみ入力された名前で更新する
-    @user.name = user_params[:name] if params[:commit_type] == "change"
-    # ボタンを押した時点で名前を確認済みにする
+    # フォームに入力されている名前を設定し、確認済みにする
+    @user.name = user_params[:name]
     @user.name_confirmed_at = Time.current
 
     if @user.save

--- a/app/controllers/name_confirmations_controller.rb
+++ b/app/controllers/name_confirmations_controller.rb
@@ -1,0 +1,44 @@
+class NameConfirmationsController < ApplicationController
+  # ユーザがログインしているかどうかを確認し、ログインしていない場合はユーザをログインページにリダイレクトする。
+  before_action :authenticate_user!
+  # 名前を確認済みのユーザーには表示しない
+  before_action :redirect_if_name_confirmed
+
+  def new
+    # モーダル以外での表示は想定していないため、直接アクセスはトップページへ遷移させる
+    return redirect_to root_path unless turbo_frame_request?
+
+    @user = current_user
+    render layout: false
+  end
+
+  def update
+    @user = current_user
+    # 「名前を変更する」を押した場合のみ入力された名前で更新する
+    @user.name = user_params[:name] if params[:commit_type] == "change"
+    # ボタンを押した時点で名前を確認済みにする
+    @user.name_confirmed_at = Time.current
+
+    if @user.save
+      respond_to do |format|
+        format.turbo_stream
+        format.html { redirect_back fallback_location: root_path }
+      end
+    else
+      # 入力エラーはモーダル内に表示する
+      render :new, layout: false, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def user_params
+    # 許可されたパラメータのみを受け取る
+    params.require(:user).permit(:name)
+  end
+
+  # 名前を確認済みならモーダルを表示する必要がないためトップページへ遷移させる
+  def redirect_if_name_confirmed
+    redirect_to root_path if current_user.name_confirmed?
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -63,6 +63,11 @@ class User < ApplicationRecord
     provider.blank? && super
   end
 
+  # 名前変更モーダルで名前を確認済みかどうか
+  def name_confirmed?
+    name_confirmed_at.present?
+  end
+
   # お気に入りタイムテーブル（event）idを取得する
   def favorite_event_id(event)
     event_favorites.find_by(event_id: event.id)&.id

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,8 +67,12 @@
     <%# メイン要素（ヘルパーでクラスを生成） %>
     <main class="<%= main_element_class %>">
       <%= yield %>
-      <%# モーダル用 %>
-      <%= turbo_frame_tag "modal" %>
+      <%# モーダル用（新規登録直後は名前変更モーダルを自動で読み込む） %>
+      <% if show_name_confirmation_modal? %>
+        <%= turbo_frame_tag "modal", src: new_name_confirmation_path %>
+      <% else %>
+        <%= turbo_frame_tag "modal" %>
+      <% end %>
     </main>
     <%# フッター %>
     <%= render "layouts/footer" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -67,7 +67,7 @@
     <%# メイン要素（ヘルパーでクラスを生成） %>
     <main class="<%= main_element_class %>">
       <%= yield %>
-      <%# モーダル用（新規登録直後は名前変更モーダルを自動で読み込む） %>
+      <%# モーダル用（名前が未確認のユーザーには名前変更モーダルを自動で読み込む） %>
       <% if show_name_confirmation_modal? %>
         <%= turbo_frame_tag "modal", src: new_name_confirmation_path %>
       <% else %>

--- a/app/views/name_confirmations/new.html.erb
+++ b/app/views/name_confirmations/new.html.erb
@@ -7,7 +7,7 @@
       <div class="max-w-md mx-auto p-6 bg-white shadow-md rounded-lg">
         <h1 class="text-gray-800 mb-4 text-2xl font-bold text-center">表示名を確認してください</h1>
         <p class="text-gray-500 text-sm mb-8">
-          他のユーザーに表示される名前をご確認ください。<br>
+          他のユーザーに表示される名前です。<br>
           変更しない場合は、そのまま「この名前で続ける」を押してください。<br>
           あとからプロフィール編集画面でも変更できます。
         </p>

--- a/app/views/name_confirmations/new.html.erb
+++ b/app/views/name_confirmations/new.html.erb
@@ -8,7 +8,8 @@
         <h1 class="text-gray-800 mb-4 text-2xl font-bold text-center">表示名を確認してください</h1>
         <p class="text-gray-500 text-sm mb-8">
           他のユーザーに表示される名前をご確認ください。<br>
-          変更しない場合は、そのまま「この名前で続ける」を押してください。
+          変更しない場合は、そのまま「この名前で続ける」を押してください。<br>
+          あとからプロフィール編集画面でも変更できます。
         </p>
         <%= form_with model: @user, url: name_confirmation_path, method: :patch, class: "space-y-6" do |f| %>
           <%# エラーメッセージ %>

--- a/app/views/name_confirmations/new.html.erb
+++ b/app/views/name_confirmations/new.html.erb
@@ -5,9 +5,10 @@
         class="fixed inset-0 z-300 flex items-center justify-center bg-black/40">
     <div class="relative max-h-[80svh] overflow-y-auto bg-white rounded-lg shadow-lg max-w-md w-full mx-4">
       <div class="max-w-md mx-auto p-6 bg-white shadow-md rounded-lg">
-        <h1 class="text-gray-800 mb-4 text-2xl font-bold text-center">名前を変更しますか？</h1>
+        <h1 class="text-gray-800 mb-4 text-2xl font-bold text-center">表示名を確認してください</h1>
         <p class="text-gray-500 text-sm mb-8">
-          マイタイムテーブルなどに表示される名前です。あとからプロフィール編集画面でも変更できます。
+          他のユーザーに表示される名前をご確認ください。<br>
+          変更しない場合は、そのまま「この名前で続ける」を押してください。
         </p>
         <%= form_with model: @user, url: name_confirmation_path, method: :patch, class: "space-y-6" do |f| %>
           <%# エラーメッセージ %>

--- a/app/views/name_confirmations/new.html.erb
+++ b/app/views/name_confirmations/new.html.erb
@@ -1,0 +1,31 @@
+<%# 名前変更モーダル（背景押下では閉じず、ボタン操作のみで閉じる） %>
+<%= turbo_frame_tag "modal" do %>
+  <div class="fixed inset-0 z-300 flex items-center justify-center bg-black/40">
+    <div class="relative max-h-[80svh] overflow-y-auto bg-white rounded-lg shadow-lg max-w-md w-full mx-4">
+      <div class="max-w-md mx-auto p-6 bg-white shadow-md rounded-lg">
+        <h1 class="text-gray-800 mb-4 text-2xl font-bold text-center">お名前の確認</h1>
+        <p class="text-gray-500 text-sm mb-8">
+          マイタイムテーブルなどに表示される名前です。あとからプロフィール編集画面でも変更できます。
+        </p>
+        <%= form_with model: @user, url: name_confirmation_path, method: :patch, class: "space-y-6" do |f| %>
+          <%# エラーメッセージ %>
+          <%= render "devise/shared/error_messages", resource: @user %>
+          <%# 名前入力 %>
+          <div>
+            <%= f.label :name, "名前", class: "block text-sm font-semibold text-gray-800 mb-1" %>
+            <%= f.text_field :name,
+              class: "w-full border border-gray-300 rounded-md px-3 py-2 text-gray-800
+                      focus:outline-none focus:ring-1 focus:ring-gray-800 focus:border-gray-800" %>
+          </div>
+          <%# 名前を変更するボタン・この名前で続けるボタン %>
+          <div class="space-y-3">
+            <%= f.button "名前を変更する", name: "commit_type", value: "change",
+              class: "w-full py-2 rounded-md bg-gray-800 text-white hover:bg-gray-900 transition cursor-pointer" %>
+            <%= f.button "この名前で続ける", name: "commit_type", value: "keep",
+              class: "w-full py-2 rounded-md border border-gray-300 text-gray-800 hover:bg-gray-50 transition cursor-pointer" %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/app/views/name_confirmations/new.html.erb
+++ b/app/views/name_confirmations/new.html.erb
@@ -3,7 +3,7 @@
   <div class="fixed inset-0 z-300 flex items-center justify-center bg-black/40">
     <div class="relative max-h-[80svh] overflow-y-auto bg-white rounded-lg shadow-lg max-w-md w-full mx-4">
       <div class="max-w-md mx-auto p-6 bg-white shadow-md rounded-lg">
-        <h1 class="text-gray-800 mb-4 text-2xl font-bold text-center">お名前の確認</h1>
+        <h1 class="text-gray-800 mb-4 text-2xl font-bold text-center">名前を変更しますか？</h1>
         <p class="text-gray-500 text-sm mb-8">
           マイタイムテーブルなどに表示される名前です。あとからプロフィール編集画面でも変更できます。
         </p>
@@ -17,12 +17,10 @@
               class: "w-full border border-gray-300 rounded-md px-3 py-2 text-gray-800
                       focus:outline-none focus:ring-1 focus:ring-gray-800 focus:border-gray-800" %>
           </div>
-          <%# 名前を変更するボタン・この名前で続けるボタン %>
-          <div class="space-y-3">
-            <%= f.button "名前を変更する", name: "commit_type", value: "change",
+          <%# 入力されている名前で確定するボタン %>
+          <div>
+            <%= f.submit "この名前で続ける",
               class: "w-full py-2 rounded-md bg-gray-800 text-white hover:bg-gray-900 transition cursor-pointer" %>
-            <%= f.button "この名前で続ける", name: "commit_type", value: "keep",
-              class: "w-full py-2 rounded-md border border-gray-300 text-gray-800 hover:bg-gray-50 transition cursor-pointer" %>
           </div>
         <% end %>
       </div>

--- a/app/views/name_confirmations/new.html.erb
+++ b/app/views/name_confirmations/new.html.erb
@@ -1,6 +1,8 @@
 <%# 名前変更モーダル（背景押下では閉じず、ボタン操作のみで閉じる） %>
 <%= turbo_frame_tag "modal" do %>
-  <div class="fixed inset-0 z-300 flex items-center justify-center bg-black/40">
+  <%# 閉じたあとにブラウザバックで復元されないようキャッシュを無効にする %>
+  <div data-turbo-cache="false"
+        class="fixed inset-0 z-300 flex items-center justify-center bg-black/40">
     <div class="relative max-h-[80svh] overflow-y-auto bg-white rounded-lg shadow-lg max-w-md w-full mx-4">
       <div class="max-w-md mx-auto p-6 bg-white shadow-md rounded-lg">
         <h1 class="text-gray-800 mb-4 text-2xl font-bold text-center">名前を変更しますか？</h1>

--- a/app/views/name_confirmations/update.turbo_stream.erb
+++ b/app/views/name_confirmations/update.turbo_stream.erb
@@ -1,2 +1,4 @@
-<%# モーダルの中身を空にする %>
-<%= turbo_stream.update "modal", "" %>
+<%# モーダルを閉じる（src を取り除いて再度読み込まれないようにする） %>
+<%= turbo_stream.replace "modal" do %>
+  <%= turbo_frame_tag "modal" %>
+<% end %>

--- a/app/views/name_confirmations/update.turbo_stream.erb
+++ b/app/views/name_confirmations/update.turbo_stream.erb
@@ -1,0 +1,2 @@
+<%# モーダルの中身を空にする %>
+<%= turbo_stream.update "modal", "" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
   resources :sessions, only: [ :new ]
   # ユーザープロフィール用のルーティング
   resource :profile, only: [ :show, :edit, :update, :destroy ]
-  # 新規登録直後の名前確認用のルーティング
+  # 名前変更モーダル用のルーティング
   resource :name_confirmation, only: [ :new, :update ]
 
   # Deviseのルーティング設定でOmniauthコールバック用コントローラーを指定

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Rails.application.routes.draw do
   resources :sessions, only: [ :new ]
   # ユーザープロフィール用のルーティング
   resource :profile, only: [ :show, :edit, :update, :destroy ]
+  # 新規登録直後の名前確認用のルーティング
+  resource :name_confirmation, only: [ :new, :update ]
 
   # Deviseのルーティング設定でOmniauthコールバック用コントローラーを指定
   devise_for :users, controllers: {

--- a/db/migrate/20260731084711_add_name_confirmed_at_to_users.rb
+++ b/db/migrate/20260731084711_add_name_confirmed_at_to_users.rb
@@ -1,0 +1,13 @@
+class AddNameConfirmedAtToUsers < ActiveRecord::Migration[8.1]
+  def up
+    add_column :users, :name_confirmed_at, :datetime
+
+    # 既存ユーザーには名前変更モーダルを表示しないため、確認済みとして扱う
+    User.reset_column_information
+    User.update_all(name_confirmed_at: Time.current)
+  end
+
+  def down
+    remove_column :users, :name_confirmed_at
+  end
+end

--- a/db/migrate/20260731084711_add_name_confirmed_at_to_users.rb
+++ b/db/migrate/20260731084711_add_name_confirmed_at_to_users.rb
@@ -1,13 +1,6 @@
 class AddNameConfirmedAtToUsers < ActiveRecord::Migration[8.1]
-  def up
+  def change
+    # 既存ユーザーにも名前変更モーダルを表示するため、初期値は未設定のままにする
     add_column :users, :name_confirmed_at, :datetime
-
-    # 既存ユーザーには名前変更モーダルを表示しないため、確認済みとして扱う
-    User.reset_column_information
-    User.update_all(name_confirmed_at: Time.current)
-  end
-
-  def down
-    remove_column :users, :name_confirmed_at
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_22_021648) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_31_084711) do
   create_table "days", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.date "date", null: false
@@ -122,6 +122,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_22_021648) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "name", limit: 50, default: "", null: false
+    t.datetime "name_confirmed_at"
     t.string "provider", limit: 50, default: "", null: false
     t.datetime "remember_created_at"
     t.string "remember_token"

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -1,9 +1,26 @@
 require "test_helper"
 
 class HomeControllerTest < ActionDispatch::IntegrationTest
+  # Devise のテストヘルパーをインクルード
+  include Devise::Test::IntegrationHelpers
+
   # トップページ表示
   test "should get index" do
     get "/"
     assert_response :success
+  end
+
+  # 名前が未確認のユーザーには名前変更モーダルが自動で読み込まれる
+  test "should load name confirmation modal when name is not confirmed" do
+    sign_in users(:name_unconfirmed)
+    get "/"
+    assert_includes response.body, new_name_confirmation_path
+  end
+
+  # 名前を確認済みのユーザーには名前変更モーダルが読み込まれない
+  test "should not load name confirmation modal when name is confirmed" do
+    sign_in users(:one)
+    get "/"
+    assert_not_includes response.body, new_name_confirmation_path
   end
 end

--- a/test/controllers/name_confirmations_controller_test.rb
+++ b/test/controllers/name_confirmations_controller_test.rb
@@ -6,7 +6,7 @@ class NameConfirmationsControllerTest < ActionDispatch::IntegrationTest
 
   # 各テストの前に実行されるセットアップメソッド
   setup do
-    @user = users(:name_unconfirmed) # 名前が未確認のユーザー（新規登録直後）を利用
+    @user = users(:name_unconfirmed) # 名前が未確認のユーザーを利用
     sign_in @user # テスト用のログイン状態を再現
   end
 
@@ -68,7 +68,9 @@ class NameConfirmationsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "text/vnd.turbo-stream.html", response.media_type
     # モーダルを閉じる Turbo Stream が返っているか
-    assert_includes response.body, 'turbo-stream action="update" target="modal"'
+    assert_includes response.body, 'turbo-stream action="replace" target="modal"'
+    # 再度読み込まれないよう src が取り除かれているか
+    assert_not_includes response.body, new_name_confirmation_path
   end
 
   # 名前が空の場合は確認済みにならない

--- a/test/controllers/name_confirmations_controller_test.rb
+++ b/test/controllers/name_confirmations_controller_test.rb
@@ -14,7 +14,7 @@ class NameConfirmationsControllerTest < ActionDispatch::IntegrationTest
   test "should get new as modal" do
     get new_name_confirmation_url, headers: { "Turbo-Frame" => "modal" } # モーダルとして表示
     assert_response :success
-    assert_includes response.body, "名前を変更しますか？"
+    assert_includes response.body, "表示名を確認してください"
     assert_includes response.body, "この名前で続ける"
   end
 

--- a/test/controllers/name_confirmations_controller_test.rb
+++ b/test/controllers/name_confirmations_controller_test.rb
@@ -1,0 +1,94 @@
+require "test_helper"
+
+class NameConfirmationsControllerTest < ActionDispatch::IntegrationTest
+  # Devise のテストヘルパーをインクルード
+  include Devise::Test::IntegrationHelpers
+
+  # 各テストの前に実行されるセットアップメソッド
+  setup do
+    @user = users(:name_unconfirmed) # 名前が未確認のユーザー（新規登録直後）を利用
+    sign_in @user # テスト用のログイン状態を再現
+  end
+
+  # モーダル表示のテスト
+  test "should get new as modal" do
+    get new_name_confirmation_url, headers: { "Turbo-Frame" => "modal" } # モーダルとして表示
+    assert_response :success
+    # 選択肢が2つとも表示されていることを確認
+    assert_includes response.body, "この名前で続ける"
+    assert_includes response.body, "名前を変更する"
+  end
+
+  # モーダル以外での表示は想定していないため直接アクセスはリダイレクトされる
+  test "should redirect new when not turbo frame request" do
+    get new_name_confirmation_url
+    assert_redirected_to root_url
+  end
+
+  # ログアウト時のモーダル表示アクションのテスト
+  test "should redirect new when not logged in" do
+    sign_out @user # ログアウト状態を再現
+    get new_name_confirmation_url, headers: { "Turbo-Frame" => "modal" }
+    assert_redirected_to root_url
+  end
+
+  # 名前を確認済みのユーザーには表示されない
+  test "should redirect new when name is already confirmed" do
+    sign_out @user
+    sign_in users(:one) # 名前を確認済みのユーザーでログイン
+    get new_name_confirmation_url, headers: { "Turbo-Frame" => "modal" }
+    assert_redirected_to root_url
+  end
+
+  # 「この名前で続ける」を押した場合は名前が変更されない
+  test "should not change name when keeping current name" do
+    patch name_confirmation_url,
+      params: { commit_type: "keep", user: { name: "変更後の名前" } },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    @user.reload
+    assert_equal "Name Unconfirmed", @user.name # 名前は変更されない
+    assert @user.name_confirmed? # 名前は確認済みになる
+  end
+
+  # 「名前を変更する」を押した場合は入力された名前で更新される
+  test "should change name when changing name" do
+    patch name_confirmation_url,
+      params: { commit_type: "change", user: { name: "変更後の名前" } },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    @user.reload
+    assert_equal "変更後の名前", @user.name
+    assert @user.name_confirmed? # 名前は確認済みになる
+  end
+
+  # 確認後にモーダルが閉じる
+  test "turbo_stream: modal is closed after confirmation" do
+    patch name_confirmation_url,
+      params: { commit_type: "keep", user: { name: "Name Unconfirmed" } },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+
+    assert_response :success
+    assert_equal "text/vnd.turbo-stream.html", response.media_type
+    # モーダルを閉じる Turbo Stream が返っているか
+    assert_includes response.body, 'turbo-stream action="update" target="modal"'
+  end
+
+  # 名前が空の場合は確認済みにならない
+  test "should not confirm when name is blank" do
+    patch name_confirmation_url,
+      params: { commit_type: "change", user: { name: "" } },
+      headers: { "Turbo-Frame" => "modal" }
+    @user.reload
+    assert_equal "Name Unconfirmed", @user.name # 名前は変更されない
+    assert_not @user.name_confirmed? # 名前は未確認のまま
+    # HTTPステータスが422（バリデーションエラー）であることを確認
+    assert_response :unprocessable_entity
+  end
+
+  # ログアウト時の更新アクションのテスト
+  test "should redirect update when not logged in" do
+    sign_out @user # ログアウト状態を再現
+    patch name_confirmation_url, params: { commit_type: "change", user: { name: "Hacker" } }
+    assert_redirected_to root_url
+    assert_not @user.reload.name_confirmed? # 未ログインは更新不可
+  end
+end

--- a/test/controllers/name_confirmations_controller_test.rb
+++ b/test/controllers/name_confirmations_controller_test.rb
@@ -14,9 +14,8 @@ class NameConfirmationsControllerTest < ActionDispatch::IntegrationTest
   test "should get new as modal" do
     get new_name_confirmation_url, headers: { "Turbo-Frame" => "modal" } # モーダルとして表示
     assert_response :success
-    # 選択肢が2つとも表示されていることを確認
+    assert_includes response.body, "名前を変更しますか？"
     assert_includes response.body, "この名前で続ける"
-    assert_includes response.body, "名前を変更する"
   end
 
   # モーダル以外での表示は想定していないため直接アクセスはリダイレクトされる
@@ -40,30 +39,30 @@ class NameConfirmationsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_url
   end
 
-  # 「この名前で続ける」を押した場合は名前が変更されない
-  test "should not change name when keeping current name" do
+  # フォームに入力されている名前で更新される
+  test "should update name with submitted value" do
     patch name_confirmation_url,
-      params: { commit_type: "keep", user: { name: "変更後の名前" } },
-      headers: { "Accept" => "text/vnd.turbo-stream.html" }
-    @user.reload
-    assert_equal "Name Unconfirmed", @user.name # 名前は変更されない
-    assert @user.name_confirmed? # 名前は確認済みになる
-  end
-
-  # 「名前を変更する」を押した場合は入力された名前で更新される
-  test "should change name when changing name" do
-    patch name_confirmation_url,
-      params: { commit_type: "change", user: { name: "変更後の名前" } },
+      params: { user: { name: "変更後の名前" } },
       headers: { "Accept" => "text/vnd.turbo-stream.html" }
     @user.reload
     assert_equal "変更後の名前", @user.name
     assert @user.name_confirmed? # 名前は確認済みになる
   end
 
+  # 名前を変更しなかった場合も確認済みになる
+  test "should confirm name when name is not modified" do
+    patch name_confirmation_url,
+      params: { user: { name: @user.name } },
+      headers: { "Accept" => "text/vnd.turbo-stream.html" }
+    @user.reload
+    assert_equal "Name Unconfirmed", @user.name
+    assert @user.name_confirmed?
+  end
+
   # 確認後にモーダルが閉じる
   test "turbo_stream: modal is closed after confirmation" do
     patch name_confirmation_url,
-      params: { commit_type: "keep", user: { name: "Name Unconfirmed" } },
+      params: { user: { name: "変更後の名前" } },
       headers: { "Accept" => "text/vnd.turbo-stream.html" }
 
     assert_response :success
@@ -75,7 +74,7 @@ class NameConfirmationsControllerTest < ActionDispatch::IntegrationTest
   # 名前が空の場合は確認済みにならない
   test "should not confirm when name is blank" do
     patch name_confirmation_url,
-      params: { commit_type: "change", user: { name: "" } },
+      params: { user: { name: "" } },
       headers: { "Turbo-Frame" => "modal" }
     @user.reload
     assert_equal "Name Unconfirmed", @user.name # 名前は変更されない
@@ -87,7 +86,7 @@ class NameConfirmationsControllerTest < ActionDispatch::IntegrationTest
   # ログアウト時の更新アクションのテスト
   test "should redirect update when not logged in" do
     sign_out @user # ログアウト状態を再現
-    patch name_confirmation_url, params: { commit_type: "change", user: { name: "Hacker" } }
+    patch name_confirmation_url, params: { user: { name: "Hacker" } }
     assert_redirected_to root_url
     assert_not @user.reload.name_confirmed? # 未ログインは更新不可
   end

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -12,6 +12,7 @@ one:
   uid: "google-uid-12345"
   username: "one"
   role: free
+  name_confirmed_at: <%= Time.current %> # 名前を確認済みであることを再現
 
 # テストユーザー2（Googleログイン用）
 two:
@@ -21,6 +22,7 @@ two:
   uid: "google-uid-67890"
   username: "two"
   role: free
+  name_confirmed_at: <%= Time.current %> # 名前を確認済みであることを再現
 
 # AI利用上限に達したユーザー
 no_ai_usage:
@@ -32,6 +34,7 @@ no_ai_usage:
   role: free
   ai_timetable_count: 10 # AI利用上限に達している状態を再現
   ai_timetable_reset_at: <%= Date.current %> # AI利用回数がリセットされたのが1ヶ月以内であることを再現
+  name_confirmed_at: <%= Time.current %> # 名前を確認済みであることを再現
 
 # 開発者ユーザー
 developer:
@@ -41,3 +44,13 @@ developer:
   uid: "google-uid-developer"
   username: "developer"
   role: developer
+  name_confirmed_at: <%= Time.current %> # 名前を確認済みであることを再現
+
+# 名前が未確認のユーザー（新規登録直後を再現）
+name_unconfirmed:
+  name: Name Unconfirmed
+  email: name.unconfirmed@example.com
+  provider: google_oauth2
+  uid: "google-uid-22222"
+  username: "name_unconfirmed"
+  role: free

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -46,7 +46,7 @@ developer:
   role: developer
   name_confirmed_at: <%= Time.current %> # 名前を確認済みであることを再現
 
-# 名前が未確認のユーザー（新規登録直後を再現）
+# 名前が未確認のユーザー（名前変更モーダルが表示される状態を再現）
 name_unconfirmed:
   name: Name Unconfirmed
   email: name.unconfirmed@example.com

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -17,6 +17,24 @@ class UserTest < ActiveSupport::TestCase
     assert user.username.bytesize >= 8
   end
 
+  # 名前の確認状況が name_confirmed_at で判定される
+  test "name_confirmed? depends on name_confirmed_at" do
+    assert users(:one).name_confirmed?
+    assert_not users(:name_unconfirmed).name_confirmed?
+  end
+
+  # Googleログインで新規作成されたユーザーは名前が未確認になる
+  test "user created by from_omniauth is not name confirmed" do
+    auth = OmniAuth::AuthHash.new(
+      provider: "google_oauth2",
+      uid: "test-google-uid-403",
+      info: { email: "user4@example.com", name: "Test User" }
+    )
+    user = User.from_omniauth(auth)
+    assert user.persisted?
+    assert_not user.name_confirmed?
+  end
+
   # 月を跨いだ時にAI利用回数がリセットされる
   test "should reset ai_timetable_count when month has changed" do
     user = @no_ai_usage_user

--- a/test/system/name_confirmations_test.rb
+++ b/test/system/name_confirmations_test.rb
@@ -28,4 +28,20 @@ class NameConfirmationsTest < ApplicationSystemTestCase
     visit root_path
     assert_no_text "名前を変更しますか？"
   end
+
+  test "確定後にブラウザバックしても再表示されない" do
+    visit root_path
+    assert_text "名前を変更しますか？"
+
+    click_on "この名前で続ける"
+    assert_no_text "名前を変更しますか？"
+
+    # 別ページへ遷移してから戻る
+    click_on "利用規約"
+    assert_current_path terms_path
+    page.go_back
+
+    assert_current_path root_path
+    assert_no_text "名前を変更しますか？"
+  end
 end

--- a/test/system/name_confirmations_test.rb
+++ b/test/system/name_confirmations_test.rb
@@ -1,0 +1,31 @@
+require "application_system_test_case"
+
+class NameConfirmationsTest < ApplicationSystemTestCase
+  include Warden::Test::Helpers
+
+  setup do
+    Warden.test_mode!
+    @user = users(:name_unconfirmed)
+    login_as @user, scope: :user
+  end
+
+  teardown do
+    Warden.test_reset!
+  end
+
+  test "名前を確定するとモーダルが閉じて再表示されない" do
+    visit root_path
+    assert_text "名前を変更しますか？"
+
+    fill_in "名前", with: "新しい名前"
+    click_on "この名前で続ける"
+
+    assert_no_text "名前を変更しますか？"
+    assert_equal "新しい名前", @user.reload.name
+    assert @user.name_confirmed?
+
+    # ページを遷移しても再表示されない
+    visit root_path
+    assert_no_text "名前を変更しますか？"
+  end
+end

--- a/test/system/name_confirmations_test.rb
+++ b/test/system/name_confirmations_test.rb
@@ -15,26 +15,26 @@ class NameConfirmationsTest < ApplicationSystemTestCase
 
   test "名前を確定するとモーダルが閉じて再表示されない" do
     visit root_path
-    assert_text "名前を変更しますか？"
+    assert_text "表示名を確認してください"
 
     fill_in "名前", with: "新しい名前"
     click_on "この名前で続ける"
 
-    assert_no_text "名前を変更しますか？"
+    assert_no_text "表示名を確認してください"
     assert_equal "新しい名前", @user.reload.name
     assert @user.name_confirmed?
 
     # ページを遷移しても再表示されない
     visit root_path
-    assert_no_text "名前を変更しますか？"
+    assert_no_text "表示名を確認してください"
   end
 
   test "確定後にブラウザバックしても再表示されない" do
     visit root_path
-    assert_text "名前を変更しますか？"
+    assert_text "表示名を確認してください"
 
     click_on "この名前で続ける"
-    assert_no_text "名前を変更しますか？"
+    assert_no_text "表示名を確認してください"
 
     # 別ページへ遷移してから戻る
     click_on "利用規約"
@@ -42,6 +42,6 @@ class NameConfirmationsTest < ApplicationSystemTestCase
     page.go_back
 
     assert_current_path root_path
-    assert_no_text "名前を変更しますか？"
+    assert_no_text "表示名を確認してください"
   end
 end


### PR DESCRIPTION
Closes #403

## 概要

名前が未確認のユーザーがページを表示したときに、名前変更モーダルを自動で表示します。Googleログイン後は元いたページに戻る流れなので、戻った先でモーダルが開きます。

背景押下・×ボタンでは閉じられず、「この名前で続ける」を押すことでのみ閉じます。

## 実施内容

- `users`に`name_confirmed_at`カラムを追加し、未設定のユーザーにモーダルを表示する
- `NameConfirmationsController`（`new` / `update`）と`/name_confirmation`のルーティングを追加
- レイアウトの共通モーダル用`turbo-frame`に、未確認のユーザーのときだけ`src`を付けてモーダルを自動で読み込む
- モーダルには名前の入力欄（現在の名前が初期値）と「この名前で続ける」ボタンのみを置き、押した時点でフォームの入力値を保存して確認済みにする
- 確定時はTurbo Streamで`turbo-frame`を`src`ごと差し替えてモーダルを閉じる

### Issueからの変更点

Issueでは選択肢を「この名前で続ける」「名前を変更する」の2つとしていましたが、名前の入力欄があれば「名前を変更する」ボタンは不要なため、ボタンは「この名前で続ける」のみにしました。入力欄を編集してから押すとその名前が保存されます。

また、これまで名前を取得していることを一切アナウンスしていないため、既存ユーザーにも次回アクセス時に表示されるようにしています（マイグレーションで既存レコードを確認済みにはしていません）。

## 発生した問題と解決方法

### 1. ボタンを押してもモーダルが閉じない

開発サーバーを起動したままマイグレーションを実行したため、動作中のプロセスが`name_confirmed_at`を認識できておらず更新に失敗していました。サーバーを再起動して解消しています。コード側の問題ではないことを、修正前のコードでもheadless Chrome上で正しく更新・クローズされることを確認して切り分けました。

### 2. 閉じたあとに再表示される余地があった

上記の切り分け中に見つかった潜在的な問題です。モーダルを読み込む`turbo-frame`には`src`が残るため、中身を空にするだけでは再読み込みされる余地がありました。`turbo_stream.replace`で`turbo-frame`ごと差し替えて`src`を取り除き、あわせてモーダルに`data-turbo-cache="false"`を付けてブラウザバック時の復元も抑止しています。

## 実施したテスト

`bin/rails test`（193件）、`bin/rails test:system`（2件）、RuboCop、Brakemanすべてパスしています。

追加したテストは以下です。

- `test/controllers/name_confirmations_controller_test.rb`
  - モーダルとして表示されること／モーダル以外の直接アクセス・未ログイン・確認済みユーザーはトップページへリダイレクトされること
  - フォームの入力値で名前が更新され、確認済みになること
  - 名前を変更しなかった場合も確認済みになること
  - モーダルを閉じるTurbo Streamが返り、`src`が取り除かれていること
  - 名前が空の場合は422になり、確認済みにならないこと
- `test/controllers/home_controller_test.rb`
  - 未確認のユーザーにはモーダルが自動で読み込まれ、確認済みのユーザーには読み込まれないこと
- `test/models/user_test.rb`
  - `name_confirmed?`の判定と、Googleログインで新規作成されたユーザーが未確認になること
- `test/system/name_confirmations_test.rb`（実ブラウザ）
  - 名前を変更して確定するとモーダルが閉じ、再訪問しても表示されないこと
  - 確定後にブラウザバックしても再表示されないこと

## レビュー時にテストするべき項目

プレビュー環境では「プレビューユーザーとしてログイン」でそのまま確認できます。

- [x] ログイン直後、元いたページに戻ったタイミングでモーダルが表示される
- [x] 背景を押しても閉じない（×ボタンがないこと）
- [x] 名前を編集せずに「この名前で続ける」を押すと、名前が変わらずモーダルが閉じる
- [x] 名前を編集して「この名前で続ける」を押すと、その名前で保存される（プロフィール画面で確認）
- [x] 一度閉じたあと、ページ遷移・リロード・ブラウザバックで再表示されない
- [x] 名前を空にして押すとエラーメッセージが表示され、モーダルが閉じない
- [x] 既存ユーザー（すでに登録済みのアカウント）でも初回アクセス時に表示される
- [x] モーダル表示中に他のモーダル（ログイン・開催日追加など）と競合しない
- [x] スマホ幅でレイアウトが崩れていない

Made with [Cursor](https://cursor.com)