### PR TITLE
fix: タイムテーブルヘッダーの長い名前がボタンに重なる問題を修正する

### DIFF
--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -22,12 +22,12 @@ module EventsHelper
     @my_timetable_view ? "bg-orange-600" : "bg-gray-800"
   end
 
-  # event-headerのタイトルを返す
+  # event-headerのタイトルを返す（鍵アイコンはビュー側で先頭に付ける）
   def event_header_title
     if @my_timetable_view
-      safe_join([ "#{@user.name}の", event_name_with_lock(@event), " マイタイムテーブル" ])
+      "#{@user.name}の#{@event.display_name} マイタイムテーブル"
     else
-      event_name_with_lock(@event)
+      @event.display_name
     end
   end
 

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -4,18 +4,17 @@ module EventsHelper
     content_tag(
       :span,
       "lock",
-      class: "material-symbols-outlined leading-none",
+      class: "material-symbols-outlined leading-none align-middle",
       style: "font-size: 1rem;"
     )
   end
 
   # 非公開時は左端に鍵アイコンを付けたタイムテーブル名を返す
+  # インライン要素のみで組み立て、囲み側の truncate / line-clamp を効かせる
   def event_name_with_lock(event)
     return event.display_name if event.is_published?
 
-    content_tag(:span, class: "inline-flex items-center gap-1 align-middle leading-none") do
-      safe_join([ lock_icon, event.display_name ], " ")
-    end
+    safe_join([ lock_icon, event.display_name ], " ")
   end
 
   # event-headerの色のクラスを返す

--- a/app/helpers/events_helper.rb
+++ b/app/helpers/events_helper.rb
@@ -1,20 +1,22 @@
 module EventsHelper
-  # 非公開タイムテーブル用の鍵アイコン
-  def lock_icon
+  # 非公開タイムテーブル用の鍵アイコン（公開時はnilを返す）
+  # align-middleはインライン文脈（一覧カード・概要ページ）用、
+  # shrink-0はflex文脈（event-header）でアイコンが潰れないようにするためのもの
+  def lock_icon_for(event)
+    return if event.is_published?
+
     content_tag(
       :span,
       "lock",
-      class: "material-symbols-outlined leading-none align-middle",
+      class: "material-symbols-outlined leading-none align-middle shrink-0",
       style: "font-size: 1rem;"
     )
   end
 
   # 非公開時は左端に鍵アイコンを付けたタイムテーブル名を返す
-  # インライン要素のみで組み立て、囲み側の truncate / line-clamp を効かせる
+  # インライン要素のみで組み立て、囲み側の`truncate`/`line-clamp`を効かせる
   def event_name_with_lock(event)
-    return event.display_name if event.is_published?
-
-    safe_join([ lock_icon, event.display_name ], " ")
+    safe_join([ lock_icon_for(event), event.display_name ].compact, " ")
   end
 
   # event-headerの色のクラスを返す

--- a/app/views/layouts/_event-header.html.erb
+++ b/app/views/layouts/_event-header.html.erb
@@ -1,15 +1,15 @@
 <%# イベント用ヘッダー (@show_event_headerがtrueの場合のみ表示) %>
 <% if @show_event_header %>
-  <header class="fixed top-8 z-160 left-0 w-full p-2 h-8 flex justify-center items-center
+  <header class="fixed top-8 z-160 left-0 w-full p-2 h-8 flex justify-center items-center gap-2
                 <%= event_header_color %>">
-    <div class="flex-1">
+    <div class="w-6 shrink-0 flex items-center">
       <%= render "events/favorite_button", event: @event %>
     </div>
-    <h1 class="text-sm text-white truncate text-center flex-none max-w-[95%] flex items-center justify-center leading-none">
+    <h1 class="text-sm text-white truncate text-center flex-1 min-w-0 leading-none">
       <%= event_header_title %>
     </h1>
     <%# 共有ボタン（data-urlで読み込ませたいURLを指定する） %>
-    <div class="flex-1 flex justify-end">
+    <div class="w-6 shrink-0 flex items-center justify-end">
       <button
           data-controller="modal"
           data-action="click->modal#open"

--- a/app/views/layouts/_event-header.html.erb
+++ b/app/views/layouts/_event-header.html.erb
@@ -2,13 +2,17 @@
 <% if @show_event_header %>
   <header class="fixed top-8 z-160 left-0 w-full p-2 h-8 flex justify-center items-center gap-2
                 <%= event_header_color %>">
+    <%# マイタイムテーブルではお気に入りボタンを出さないが、
+        右の共有ボタンと幅を揃えてタイトルを中央に保つため枠だけ残す %>
     <div class="w-6 shrink-0 flex items-center">
       <%= render "events/favorite_button", event: @event %>
     </div>
+    <% header_title = event_header_title %>
     <%# 非公開の場合はタイトル全体の先頭に鍵アイコンを付ける %>
     <h1 class="text-sm text-white flex-1 min-w-0 flex items-center justify-center gap-1 leading-none">
       <%= lock_icon_for(@event) %>
-      <span class="truncate"><%= event_header_title %></span>
+      <%# 省略された場合でも全文を確認できるようにtitle属性を付ける %>
+      <span class="truncate" title="<%= header_title %>"><%= header_title %></span>
     </h1>
     <%# 共有ボタン（data-urlで読み込ませたいURLを指定する） %>
     <div class="w-6 shrink-0 flex items-center justify-end">

--- a/app/views/layouts/_event-header.html.erb
+++ b/app/views/layouts/_event-header.html.erb
@@ -7,7 +7,7 @@
     </div>
     <%# 非公開の場合はタイトル全体の先頭に鍵アイコンを付ける %>
     <h1 class="text-sm text-white flex-1 min-w-0 flex items-center justify-center gap-1 leading-none">
-      <%= lock_icon unless @event.is_published? %>
+      <%= lock_icon_for(@event) %>
       <span class="truncate"><%= event_header_title %></span>
     </h1>
     <%# 共有ボタン（data-urlで読み込ませたいURLを指定する） %>

--- a/app/views/layouts/_event-header.html.erb
+++ b/app/views/layouts/_event-header.html.erb
@@ -5,8 +5,10 @@
     <div class="w-6 shrink-0 flex items-center">
       <%= render "events/favorite_button", event: @event %>
     </div>
-    <h1 class="text-sm text-white truncate text-center flex-1 min-w-0 leading-none">
-      <%= event_header_title %>
+    <%# 非公開の場合はタイトル全体の先頭に鍵アイコンを付ける %>
+    <h1 class="text-sm text-white flex-1 min-w-0 flex items-center justify-center gap-1 leading-none">
+      <%= lock_icon unless @event.is_published? %>
+      <span class="truncate"><%= event_header_title %></span>
     </h1>
     <%# 共有ボタン（data-urlで読み込ませたいURLを指定する） %>
     <div class="w-6 shrink-0 flex items-center justify-end">


### PR DESCRIPTION
## 概要

タイムテーブル名が長い場合に、タイムテーブルヘッダーのタイトルが両端のお気に入りボタン・シェアボタンに重なってしまう問題を修正しました。

## 原因と修正内容

### 1. タイトルが両端のボタンに重なる

タイトルの `h1` が `flex-none max-w-[95%]` だったため、名前が長いとタイトルがヘッダー幅の95%まで広がり、両端の `flex-1` のボタン枠が0幅まで潰されてボタンとタイトルが重なっていました。また `h1` に `display: flex` が付いていたため `truncate` の省略記号も効いていませんでした。

- 両端のボタン枠を固定幅（`w-6 shrink-0`）にし、タイトル側を `flex-1 min-w-0` で縮むようにした
- `gap-2` でタイトルとボタンの間隔を確保した

### 2. 鍵アイコン付きの名前に省略記号が付かない

非公開タイムテーブルの名前は `inline-flex` の要素で囲まれていたため、囲み側の `truncate` / `line-clamp` の省略記号が効かず、文字が途中で切れて見えていました。インライン要素のみで組み立てるようにしました（タイムテーブル一覧カードの `line-clamp-1` にも効きます）。

### 3. 非公開時にタイムテーブル名が上寄りになる

鍵アイコン（16px）をタイトル文字列（14px・`leading-none`）の中にインラインで混ぜていたため、行ボックスがアイコン基準に広がり文字だけが上にずれていました。`h1` を flex にして鍵アイコンを独立した要素として中央寄せし、名前側の `span` で `truncate` するようにしました。

### 4. マイタイムテーブルの鍵アイコンの位置

マイタイムテーブルではタイトルが「ユーザー名の + タイムテーブル名 + マイタイムテーブル」となるため、鍵アイコンがタイトルの途中に表示されていました。ユーザー名を含むタイトル全体の先頭に付くようにしました。

## テスト

- `bin/rails test`: 193 runs, 487 assertions, 0 failures, 0 errors
- `bundle exec rubocop`: 152 files, no offenses
- headless Chrome（幅390px）で以下の表示を目視確認
  - 公開タイムテーブル: 長い名前 / 短い名前
  - 非公開タイムテーブル: 長い名前 / 短い名前
  - マイタイムテーブル: 公開・非公開、長い名前 / 短い名前
  - ヘルパー変更の影響範囲: タイムテーブル一覧カード、タイムテーブル概要ページ

## 確認方法

1. 長い名前のタイムテーブルを開き、ヘッダーのタイトルが両端のボタンに重ならず末尾が「…」で省略されること
2. 非公開タイムテーブルで、鍵アイコンとタイムテーブル名の縦位置が揃っていること
3. 非公開タイムテーブルのマイタイムテーブルページで、鍵アイコンがユーザー名の前に表示されること

Made with [Cursor](https://cursor.com)