### PR TITLE
feat: Dependabot PRをグループ問わず自動マージ対象にする

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -17,8 +17,8 @@ jobs:
         with:
           github-token: "${{ secrets.GITHUB_TOKEN }}"
 
-      - name: Enable auto-merge for bundler-updates
-        if: steps.metadata.outputs.dependency-group == 'bundler-updates'
+      - name: Enable auto-merge
+        if: contains(fromJSON('["bundler-updates", "bundler-security", "actions-updates", "actions-security"]'), steps.metadata.outputs.dependency-group)
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,14 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
-      - name: Fetch Dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
-        with:
-          github-token: "${{ secrets.GITHUB_TOKEN }}"
-
       - name: Enable auto-merge
-        if: contains(fromJSON('["bundler-updates", "bundler-security", "actions-updates", "actions-security"]'), steps.metadata.outputs.dependency-group)
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}


### PR DESCRIPTION
## Summary
- #443 で追加した Dependabot auto-merge workflow の対象を、`bundler-updates` グループ限定から Dependabot PR 全般に拡張
- `bundler-security` / `actions-updates` / `actions-security` を含むすべての PR が、CI 通過後に自動で squash merge される
- グループ名で絞り込まない方針にしたため、判定に使っていた `dependabot/fetch-metadata` ステップを削除

対象グループを列挙する方式だと `dependabot.yml` にグループを追加するたびに workflow の更新が必要になるため、job レベルの `github.event.pull_request.user.login == 'dependabot[bot]'` のみを条件としました。Dependabot 以外の PR では job 自体がスキップされます。

## Test plan
- [ ] Dependabot が作成した `bundler-security` PR で auto-merge が有効になること
- [ ] Dependabot が作成した `actions-updates` PR で auto-merge が有効になること
- [ ] 従来どおり `bundler-updates` PR でも auto-merge が有効になること
- [ ] 必須CIが成功後に PR が自動で squash merge されること
- [ ] 必須CIが失敗した PR はマージされずに留まること
- [x] Dependabot 以外のユーザーの PR では job 自体がスキップされること