### PR TITLE
feat: サイトマップを動的に生成する

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,6 +75,9 @@ gem "rinku"
 # OpenAI APIを使用するためのgem
 gem "openai"
 
+# サイトマップ生成
+gem "sitemap_generator"
+
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -393,6 +393,8 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 4.0)
       websocket (~> 1.0)
+    sitemap_generator (7.1.1)
+      builder (~> 3.0)
     snaky_hash (2.0.6)
       hashie (>= 0.1.0, < 6)
       version_gem (>= 1.1.8, < 3)
@@ -511,6 +513,7 @@ DEPENDENCIES
   rubocop-rails-omakase
   ruby-vips (>= 2.2.1)
   selenium-webdriver
+  sitemap_generator
   solid_cable
   solid_cache
   solid_queue

--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,0 +1,12 @@
+class SitemapsController < ApplicationController
+  # 毎リクエストで全イベントを走査しないよう、生成したXMLを一定時間キャッシュする
+  CACHE_EXPIRES_IN = 1.hour
+
+  def show
+    xml = Rails.cache.fetch("sitemap/#{request.base_url}", expires_in: CACHE_EXPIRES_IN) do
+      SitemapBuilder.build(host: request.base_url)
+    end
+
+    render xml: xml
+  end
+end

--- a/app/services/sitemap_builder.rb
+++ b/app/services/sitemap_builder.rb
@@ -1,0 +1,58 @@
+# サイトマップのXMLを組み立てるサービスクラス
+# Renderのコンテナはファイルシステムが揮発するため、public/には書き出さずXML文字列を返す
+class SitemapBuilder
+  # sitemap_generator にファイルではなくメモリ上へ書き出させるためのアダプター
+  class MemoryAdapter
+    attr_reader :xml
+
+    def write(_location, raw_data)
+      @xml = raw_data
+    end
+  end
+
+  # host は "https://minnanotimetable.com" のようなプロトコル付きのホスト
+  def self.build(host:)
+    adapter = MemoryAdapter.new
+    events = published_events_with_lastmod
+    # トップページとイベント一覧はイベントの更新に追従して変わる
+    events_lastmod = events.values.max
+
+    SitemapGenerator::LinkSet.new(
+      default_host: host,
+      adapter: adapter,
+      compress: false,      # gzipせずXMLのまま返す
+      create_index: false,  # サイトマップは1ファイルのみ
+      include_root: false,  # ルートは他の静的ページと合わせて明示的に追加する
+      verbose: false        # 標準出力へのサマリー出力（ファイルサイズの取得）を止める
+    ).create do
+      add root_path, lastmod: events_lastmod, changefreq: "daily", priority: 1.0
+      add events_path, lastmod: events_lastmod, changefreq: "daily", priority: 0.9
+      # 更新日時を持たないページは lastmod を出力しない
+      add terms_path, lastmod: nil, changefreq: "yearly", priority: 0.3
+      add privacy_path, lastmod: nil, changefreq: "yearly", priority: 0.3
+
+      events.each do |event, lastmod|
+        add event_path(event.event_key), lastmod: lastmod, changefreq: "weekly", priority: 0.7
+        add show_timetable_path(event.event_key), lastmod: lastmod, changefreq: "weekly", priority: 0.8
+      end
+    end
+
+    adapter.xml
+  end
+
+  # 公開イベントをキー、最終更新日時（イベント自体と出演情報のうち新しい方）を値とするHashを返す
+  def self.published_events_with_lastmod
+    events = Event.where(is_published: true).order(:id).to_a
+    # 出演情報を追加してもイベント自体の updated_at は変わらないため、別途取得する
+    performances_updated_at = Performance
+      .joins(:performer)
+      .where(performers: { event_id: events.map(&:id) })
+      .group("performers.event_id")
+      .maximum(:updated_at)
+
+    events.index_with do |event|
+      [ event.updated_at, performances_updated_at[event.id] ].compact.max
+    end
+  end
+  private_class_method :published_events_with_lastmod
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -42,19 +42,19 @@
     <%# Includes all stylesheet files in app/assets/stylesheets %>
     <%= stylesheet_link_tag :app, "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
-  </head>
-  <%# Google Analyticsを利用するために必要なコード（本番環境のみ実行される） %>
-  <% if Rails.env.production? && !preview_environment? %>
-    <%# Google tag (gtag.js) %>
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-X5QSF6431B"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
+    <%# Google Analyticsを利用するために必要なコード（本番環境のみ実行される） %>
+    <% if Rails.env.production? && !preview_environment? %>
+      <%# Google tag (gtag.js) %>
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-X5QSF6431B"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
 
-      gtag('config', 'G-X5QSF6431B');
-    </script>
-  <% end %>
+        gtag('config', 'G-X5QSF6431B');
+      </script>
+    <% end %>
+  </head>
   <body class="min-h-svh flex flex-col">
     <%# メインヘッダー(@hidden_headerがtrueの場合は非表示) %>
     <%= render "layouts/header" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -81,6 +81,9 @@ Rails.application.routes.draw do
   get "/terms", to: "static_pages#terms"
   get "/privacy", to: "static_pages#privacy"
 
+  # サイトマップ（リクエストごとに動的に生成する）
+  get "/sitemap.xml", to: "sitemaps#show", as: :sitemap, defaults: { format: "xml" }
+
   # イベント詳細ページ（/:event_key）
   get "/t/:event_key", to: "timetables#show", as: :show_timetable
 

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,1 +1,2 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+Sitemap: https://minnanotimetable.com/sitemap.xml

--- a/test/controllers/sitemaps_controller_test.rb
+++ b/test/controllers/sitemaps_controller_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class SitemapsControllerTest < ActionDispatch::IntegrationTest
+  test "should get sitemap as xml" do
+    get sitemap_path
+    assert_response :success
+    assert_equal "application/xml", response.media_type
+  end
+
+  # 静的ページがサイトマップに含まれる
+  test "sitemap includes static pages" do
+    get sitemap_path
+    [ "http://www.example.com", "http://www.example.com/events", "http://www.example.com/terms", "http://www.example.com/privacy" ].each do |url|
+      assert_includes response.body, "<loc>#{url}</loc>"
+    end
+  end
+
+  # 公開イベントのイベントページとタイムテーブルページがサイトマップに含まれる
+  test "sitemap includes published events" do
+    get sitemap_path
+    event = events(:one)
+    assert_includes response.body, "<loc>http://www.example.com/events/#{event.event_key}</loc>"
+    assert_includes response.body, "<loc>http://www.example.com/t/#{event.event_key}</loc>"
+  end
+
+  # 非公開イベントはサイトマップに含まれない
+  test "sitemap excludes unpublished events" do
+    get sitemap_path
+    event = events(:unpublished)
+    assert_not_includes response.body, "<loc>http://www.example.com/events/#{event.event_key}</loc>"
+    assert_not_includes response.body, "<loc>http://www.example.com/t/#{event.event_key}</loc>"
+  end
+
+  # マイタイムテーブルは重複コンテンツになるためサイトマップに含めない
+  test "sitemap excludes my timetables" do
+    get sitemap_path
+    assert_not_includes response.body, "<loc>http://www.example.com/t/#{events(:one).event_key}/"
+  end
+end


### PR DESCRIPTION
## Summary
- `sitemap_generator` を導入し、`/sitemap.xml` で公開ページのサイトマップを動的に生成・キャッシュする
- `robots.txt` に Sitemap 宣言を追加する
- GA4タグを `</head>` と `<body>` の間から `<head>` 内へ移動する

Closes #319

## Test plan
- [x] ローカルで `http://localhost:3000/sitemap.xml` を開き、静的ページと公開イベントのURLが含まれること
- [x] 非公開イベントとマイタイムテーブルのURLが含まれないこと
- [x] `http://localhost:3000/robots.txt` に `Sitemap: https://minnanotimetable.com/sitemap.xml` があること
- [x] 本番デプロイ後、Search Consoleのサイトマップに `sitemap.xml` を送信する


Made with [Cursor](https://cursor.com)