### PR TITLE
fix: サイトマップ生成でRails.cacheを使わないようにする

### DIFF
--- a/app/controllers/sitemaps_controller.rb
+++ b/app/controllers/sitemaps_controller.rb
@@ -1,12 +1,7 @@
 class SitemapsController < ApplicationController
-  # 毎リクエストで全イベントを走査しないよう、生成したXMLを一定時間キャッシュする
-  CACHE_EXPIRES_IN = 1.hour
-
   def show
-    xml = Rails.cache.fetch("sitemap/#{request.base_url}", expires_in: CACHE_EXPIRES_IN) do
-      SitemapBuilder.build(host: request.base_url)
-    end
-
+    # Solid Cache（solid_cache_entries）が未整備のため Rails.cache は使わず都度生成する
+    xml = SitemapBuilder.build(host: request.base_url)
     render xml: xml
   end
 end


### PR DESCRIPTION
## Summary
- `/sitemap.xml` が本番で `PG::UndefinedTable`（`solid_cache_entries` 未作成）により500になっていたため、`Rails.cache` を外して都度生成する
- Solid Cache未整備の間はサイトマップだけキャッシュに依存しない

## Test plan
- [x] デプロイ後に https://minnanotimetable.com/sitemap.xml が200でXMLを返すこと
- [x] Renderログに `solid_cache_entries` 関連のエラーが出ないこと
- [x] ローカルで `http://localhost:3000/sitemap.xml` が従来どおり表示されること


Made with [Cursor](https://cursor.com)