### PR TITLE
feat: canonicalタグを追加する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -4,6 +4,15 @@ module ApplicationHelper
     time&.strftime("%H:%M")
   end
 
+  # 正規URLを返す（クエリパラメータは除く）。content_for :canonical で上書き可能
+  # タイムテーブルの ?d= など日付違いURLの重複インデックスを防ぐ
+  def canonical_url
+    if content_for?(:canonical)
+      content_for(:canonical)
+    else
+      "#{request.base_url}#{request.path}"
+    end
+  end
 
   # main要素のクラスを返す
   def main_element_class

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -13,11 +13,13 @@
     <% if Rails.env.staging? || (@event.present? && !@event.is_published?) %>
       <meta name="robots" content="noindex, nofollow">
     <% end %>
+    <%# canonical（クエリパラメータを除いた正規URL。?d= などによる重複インデックスを防ぐ） %>
+    <link rel="canonical" href="<%= canonical_url %>">
     <%# OGP画像 %>
     <meta property="og:type" content="website">
     <meta property="og:site_name" content="みんなのタイムテーブル">
     <meta property="og:locale" content="ja_JP">
-    <meta property="og:url" content="<%= request.original_url %>">
+    <meta property="og:url" content="<%= canonical_url %>">
     <meta property="og:image" content="<%= image_url('ogp.png') %>">
     <meta property="og:title" content="<%= content_for?(:title) ? yield(:title) : "みんなのタイムテーブル" %>">
     <meta property="og:description" content="<%= content_for?(:description) ? yield(:description) : "" %>">

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -10,6 +10,12 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # トップページにcanonicalタグが付与される
+  test "index includes canonical url" do
+    get "/"
+    assert_select "link[rel=canonical][href=?]", "http://www.example.com/"
+  end
+
   # 名前が未確認のユーザーには名前変更モーダルが自動で読み込まれる
   test "should load name confirmation modal when name is not confirmed" do
     sign_in users(:name_unconfirmed)

--- a/test/controllers/timetables_controller_test.rb
+++ b/test/controllers/timetables_controller_test.rb
@@ -76,6 +76,15 @@ class TimetablesControllerTest < ActionDispatch::IntegrationTest
     assert_select "p", text: @performance2.performer.performer_name_tag.name, count: 0
   end
 
+  # canonicalはクエリパラメータを含まない正規URLを指す
+  test "canonical url excludes date query parameter" do
+    get show_timetable_path(@event.event_key, d: @day2.date)
+    assert_response :success
+    canonical = "http://www.example.com/t/#{@event.event_key}"
+    assert_select "link[rel=canonical][href=?]", canonical
+    assert_select "meta[property='og:url'][content=?]", canonical
+  end
+
   # 出演情報が0件の場合もタイムテーブルを表示できる
   test "should show event timetable by event_key when no performances" do
     get show_timetable_path(@no_performance_event.event_key)


### PR DESCRIPTION
## Summary
- 全ページの`<head>`に`canonical`タグを追加し、クエリパラメータ（`?d=`など）を除いた正規URLを明示する
- `og:url`も同じ正規URLに揃え、日付違いURLの重複インデックスを防ぐ
- Closes #464

## Test plan
- [x] トップページのHTMLソースに`<link rel="canonical" href="...">`があることを確認
- [x] タイムテーブルページ（`/t/:event_key`）で、日付なし・`?d=`付きの両方でcanonicalが同じパスを指すことを確認
- [x] `og:url`がcanonicalと同じ値になっていることを確認
- [x] `bin/rails test test/controllers/home_controller_test.rb test/controllers/timetables_controller_test.rb` が通ることを確認


Made with [Cursor](https://cursor.com)