### PR TITLE
feat: マイタイムテーブルを検索エンジンから除外する

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -9,8 +9,8 @@
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
-    <%# ステージング環境、または非公開タイムテーブルでは検索エンジンにインデックスさせない %>
-    <% if Rails.env.staging? || (@event.present? && !@event.is_published?) %>
+    <%# ステージング・非公開・マイタイムテーブルは検索エンジンにインデックスさせない（重複コンテンツ対策） %>
+    <% if Rails.env.staging? || (@event.present? && !@event.is_published?) || @my_timetable_view %>
       <meta name="robots" content="noindex, nofollow">
     <% end %>
     <%# canonical（クエリパラメータを除いた正規URL。?d= などによる重複インデックスを防ぐ） %>

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,6 +1,6 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
 User-agent: *
-# マイタイムテーブル（/t/:event_key/:username）は本体と重複しやすいためクロールを抑制する
+# Disallow my timetables (/t/:event_key/:username) to reduce duplicate content crawl
 Disallow: /t/*/*
 
 Sitemap: https://minnanotimetable.com/sitemap.xml

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,2 +1,6 @@
 # See https://www.robotstxt.org/robotstxt.html for documentation on how to use the robots.txt file
+User-agent: *
+# マイタイムテーブル（/t/:event_key/:username）は本体と重複しやすいためクロールを抑制する
+Disallow: /t/*/*
+
 Sitemap: https://minnanotimetable.com/sitemap.xml

--- a/test/controllers/my_timetables_controller_test.rb
+++ b/test/controllers/my_timetables_controller_test.rb
@@ -33,6 +33,13 @@ class MyTimetablesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # マイタイムテーブルは検索エンジンにインデックスさせない
+  test "my timetable includes noindex robots meta" do
+    get show_my_timetable_path(event_key: @event.event_key, username: @user.username)
+    assert_response :success
+    assert_select "meta[name=robots][content='noindex, nofollow']"
+  end
+
   test "should not get unpublished my_timetable with logout" do
     sign_out @user
     unpublished_event = events(:unpublished)

--- a/test/controllers/timetables_controller_test.rb
+++ b/test/controllers/timetables_controller_test.rb
@@ -85,6 +85,13 @@ class TimetablesControllerTest < ActionDispatch::IntegrationTest
     assert_select "meta[property='og:url'][content=?]", canonical
   end
 
+  # 本体の公開タイムテーブルはインデックス対象（noindexしない）
+  test "published timetable does not include noindex robots meta" do
+    get show_timetable_path(@event.event_key)
+    assert_response :success
+    assert_select "meta[name=robots][content='noindex, nofollow']", count: 0
+  end
+
   # 出演情報が0件の場合もタイムテーブルを表示できる
   test "should show event timetable by event_key when no performances" do
     get show_timetable_path(@no_performance_event.event_key)


### PR DESCRIPTION
## Summary
- マイタイムテーブル（`/t/:event_key/:username`）に `noindex, nofollow` メタを付与し、検索エンジンへのインデックスを抑制する
- `robots.txt` で `/t/*/*` を `Disallow` し、マイタイムテーブルのクロールを抑制する（本体の `/t/:event_key` は対象外）
- 関連テストを追加

Closes: #465

## Test plan
- [x] 公開イベントのマイタイムテーブルを開き、`<meta name="robots" content="noindex, nofollow">` があることを確認する
- [x] 本体の公開タイムテーブルでは同メタが無いことを確認する
- [ ] `/robots.txt` に `Disallow: /t/*/*` があることを確認する
- [x] `bin/rails test test/controllers/my_timetables_controller_test.rb test/controllers/timetables_controller_test.rb` が通る


Made with [Cursor](https://cursor.com)