### PR TITLE
feat: フッターに稼働状況リンクを追加する

### DIFF
--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -12,6 +12,10 @@
                     class: "text-gray-700 hover:text-gray-900 hover:underline",
                     target: "_blank",
                     rel: "noopener noreferrer" %>
+          <%= link_to "稼働状況", "https://stats.uptimerobot.com/ZRof25OUD7",
+                    class: "text-gray-700 hover:text-gray-900 hover:underline",
+                    target: "_blank",
+                    rel: "noopener noreferrer" %>
           <% if user_signed_in? && current_user.developer? %>
             <%= link_to "管理画面（開発者向け）", admin_dashboard_path,
                 class: "text-gray-700 hover:text-gray-900 hover:underline" %>

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -10,4 +10,12 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     get privacy_path
     assert_response :success
   end
+
+  test "footer includes status page link" do
+    get terms_path
+    assert_response :success
+    assert_select "a[href=?][target=_blank][rel='noopener noreferrer']",
+                  "https://stats.uptimerobot.com/ZRof25OUD7",
+                  text: "稼働状況"
+  end
 end


### PR DESCRIPTION
## Summary
- フッターにUptimeRobotステータスページへの「稼働状況」リンクを追加
- 利用規約・プライバシーポリシー・お問い合わせと並べて表示

## Test plan
- [x] トップや利用規約ページのフッターに「稼働状況」が表示されること
- [x] リンク先が https://stats.uptimerobot.com/ZRof25OUD7 であること
- [x] 新しいタブで開くこと
- [x] `bin/rails test test/controllers/static_pages_controller_test.rb` が通ること


Made with [Cursor](https://cursor.com)