### PR TITLE
feat: タイムテーブル領域全体がスクロールしないようにする

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -14,10 +14,20 @@ module ApplicationHelper
     end
   end
 
+  # body要素のクラスを返す
+  # タイムテーブル画面はページ全体スクロールを止め、内側コンテナのみスクロールさせる
+  def body_element_class
+    if defined?(@timetable_view) && @timetable_view
+      "h-svh flex flex-col overflow-hidden"
+    else
+      "min-h-svh flex flex-col"
+    end
+  end
+
   # main要素のクラスを返す
   def main_element_class
     if defined?(@timetable_view) && @timetable_view
-      ""
+      "min-h-0 flex-1 overflow-hidden"
     elsif defined?(@show_event_header) && @show_event_header
       "m-2 pt-24"
     elsif defined?(@page_title) && @page_title.present?

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -57,7 +57,7 @@
       </script>
     <% end %>
   </head>
-  <body class="min-h-svh flex flex-col">
+  <body class="<%= body_element_class %>">
     <%# メインヘッダー(@hidden_headerがtrueの場合は非表示) %>
     <%= render "layouts/header" %>
     <%# セカンドヘッダー（@page_title が設定されている場合のみ表示する） %>

--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -19,9 +19,9 @@
 <% end %>
 <% if @performances.present? %>
   <%# タイムテーブル表示画面のメインコンテナ（画面全体の高さに設定する） %>
-  <div class="h-svh flex flex-col overflow-hidden pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
-    <%# スクロールコンテナ（ヘッダーと日付選択タブの高さ分下げた位置に配置する） %>
-    <div class="flex-1 pt-24 overflow-auto relative">
+  <div class="h-full flex flex-col overflow-hidden pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
+    <%# スクロールコンテナ（ヘッダーと日付選択タブの高さ分下げた位置に配置する。min-h-0で内側だけスクロール） %>
+    <div class="flex-1 min-h-0 pt-24 overflow-auto overscroll-none relative">
       <%# 横幅確保 %>
       <div class="min-w-max">
         <%# ヘッダー行 %>
@@ -106,7 +106,7 @@
   </div>
 <% else %>
   <%# ===== お気に入り出演情報が0件の場合 ===== %>
-  <div class="h-svh p-12 flex flex-col items-center justify-center pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
+  <div class="h-full p-12 flex flex-col items-center justify-center pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
     <% if my_timetable_owner? %>
       <p class="text-gray-800 mb-4">出演情報をお気に入り登録すると、<br>
         ここにマイタイムテーブルが表示されます！</p>

--- a/app/views/timetables/show.html.erb
+++ b/app/views/timetables/show.html.erb
@@ -24,9 +24,9 @@
 <% end %>
 <% if @performances.present? %>
   <%# タイムテーブル表示画面のメインコンテナ（画面全体の高さに設定する） %>
-  <div class="h-svh flex flex-col overflow-hidden pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
-    <%# スクロールコンテナ（ヘッダーと日付選択タブの高さ分下げた位置に配置する） %>
-    <div class="flex-1 pt-24 overflow-auto relative">
+  <div class="h-full flex flex-col overflow-hidden pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
+    <%# スクロールコンテナ（ヘッダーと日付選択タブの高さ分下げた位置に配置する。min-h-0で内側だけスクロール） %>
+    <div class="flex-1 min-h-0 pt-24 overflow-auto overscroll-none relative">
       <%# 横幅確保 %>
       <div class="min-w-max">
         <%# ヘッダー行 %>
@@ -107,7 +107,7 @@
   <% end %>
 <% else %>
   <%# ===== 情報が揃った出演情報が0件の場合 ===== %>
-  <div class="h-svh p-12 flex flex-col items-center justify-center pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
+  <div class="h-full p-12 flex flex-col items-center justify-center pb-[calc(5.25rem+env(safe-area-inset-bottom))]">
     <% if user_signed_in? && current_user == @event.user %>
       <div class="max-w-md flex flex-col justify-center items-center">
         <p class="text-gray-500 mb-4">タイムテーブルを完成させましょう！</p>

--- a/test/controllers/my_timetables_controller_test.rb
+++ b/test/controllers/my_timetables_controller_test.rb
@@ -40,6 +40,15 @@ class MyTimetablesControllerTest < ActionDispatch::IntegrationTest
     assert_select "meta[name=robots][content='noindex, nofollow']"
   end
 
+  # マイタイムテーブルもページ全体ではなく内側コンテナのみスクロールする
+  test "my timetable page locks body scroll and scrolls inner container only" do
+    get show_my_timetable_path(event_key: @event.event_key, username: @user.username)
+    assert_response :success
+    assert_select "body.h-svh.overflow-hidden"
+    assert_select "main.min-h-0.overflow-hidden"
+    assert_select "div.flex-1.min-h-0.overflow-auto.overscroll-none"
+  end
+
   test "should not get unpublished my_timetable with logout" do
     sign_out @user
     unpublished_event = events(:unpublished)

--- a/test/controllers/timetables_controller_test.rb
+++ b/test/controllers/timetables_controller_test.rb
@@ -66,6 +66,15 @@ class TimetablesControllerTest < ActionDispatch::IntegrationTest
     assert_select "a[href=?][aria-label=?]", new_event_performance_path(@event.event_key), "出演情報を追加"
   end
 
+  # タイムテーブル画面はページ全体ではなく内側コンテナのみスクロールする
+  test "timetable page locks body scroll and scrolls inner container only" do
+    get show_timetable_path(@event.event_key)
+    assert_response :success
+    assert_select "body.h-svh.overflow-hidden"
+    assert_select "main.min-h-0.overflow-hidden"
+    assert_select "div.flex-1.min-h-0.overflow-auto.overscroll-none"
+  end
+
   # 時刻軸に下余白分の正時（末尾の次の1つ）が表示される
   test "time axis includes bottom spacer hour" do
     get show_timetable_path(@event.event_key)


### PR DESCRIPTION
## Summary
- タイムテーブル画面で `body` / `main` を固定高さ＋`overflow-hidden` にし、ページ全体スクロールを無効化
- スクロールコンテナに `min-h-0` と `overscroll-none` を付与し、内側だけスクロールするように修正
- マイタイムテーブルにも同様の対応を適用

## Test plan
- [x] 出演情報があるタイムテーブルを開き、ページ全体がスクロールせず内側だけ動くこと
- [x] ステージヘッダー・時刻列の sticky が内側スクロールでも維持されること
- [x] オーナー表示時、下余白により末尾の出演者がボタンに隠れないこと
- [x] マイタイムテーブルでも同様に内側のみスクロールすること
- [x] タイムテーブル以外のページでは従来どおりページスクロールできること

Closes: #478

Made with [Cursor](https://cursor.com)