### PR TITLE
fix: タイムテーブル画像のクレジットをサービス名のみにする

### DIFF
--- a/app/views/timetable_images/capture.html.erb
+++ b/app/views/timetable_images/capture.html.erb
@@ -70,7 +70,7 @@
       </div>
       <p class="absolute right-2 bottom-1 z-10 m-0 p-0 text-[11px] pointer-events-none whitespace-nowrap"
          style="line-height: 1.4; color: rgba(0, 0, 0, 0.35);">
-        powered by みんなのタイムテーブル
+        みんなのタイムテーブル
       </p>
     </div>
   <% else %>
@@ -78,7 +78,7 @@
       この日の出演情報はありません
       <p class="absolute right-2 bottom-1 z-10 m-0 p-0 text-[11px] pointer-events-none whitespace-nowrap"
          style="line-height: 1.4; color: rgba(0, 0, 0, 0.35);">
-        powered by みんなのタイムテーブル
+        みんなのタイムテーブル
       </p>
     </div>
   <% end %>

--- a/test/controllers/timetable_images_controller_test.rb
+++ b/test/controllers/timetable_images_controller_test.rb
@@ -16,7 +16,6 @@ class TimetableImagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "[data-timetable-image-capture-root]"
     assert_match "みんなのタイムテーブル", response.body
-    assert_no_match "powered by", response.body
   end
 
   test "should omit favorite marker class when favorites is 0" do

--- a/test/controllers/timetable_images_controller_test.rb
+++ b/test/controllers/timetable_images_controller_test.rb
@@ -15,7 +15,8 @@ class TimetableImagesControllerTest < ActionDispatch::IntegrationTest
     get timetable_image_capture_path(type: "event", event_key: @event.event_key, d: @day.date)
     assert_response :success
     assert_select "[data-timetable-image-capture-root]"
-    assert_match "powered by みんなのタイムテーブル", response.body
+    assert_match "みんなのタイムテーブル", response.body
+    assert_no_match "powered by", response.body
   end
 
   test "should omit favorite marker class when favorites is 0" do


### PR DESCRIPTION
## Summary
- 画像右下のクレジットを `powered by みんなのタイムテーブル` から `みんなのタイムテーブル` に変更する
- 英語混じりの表記をやめ、サービス名だけにする

## 関連PR
- #483 feat: タイムテーブルを画像化して保存できるようにする

## Test plan
- [x] 共有モーダルからタイムテーブル画像を保存し、右下のクレジットが「みんなのタイムテーブル」になっていること
- [x] 「powered by」が残っていないこと