### PR TITLE
fix: Brakemanの最新版チェックを3日の猶予付きにする

### DIFF
--- a/bin/brakeman
+++ b/bin/brakeman
@@ -2,6 +2,7 @@
 require "rubygems"
 require "bundler/setup"
 
-ARGV.unshift("--ensure-latest")
+# Dependabotのversion update cooldown（3日）に合わせ、最新版が3日以上経過してから失敗させる
+ARGV.unshift("--ensure-latest", "3")
 
 load Gem.bin_path("brakeman", "brakeman")


### PR DESCRIPTION
## Summary
- `bin/brakeman` の `--ensure-latest` に3日の猶予を付ける
- Dependabotのversion update cooldown（デフォルト3日）と揃え、新バージョン公開直後の `scan_ruby` 失敗を防ぐ

## Test plan
- [x] CIの `scan_ruby` が通ること
- [x] `bin/brakeman --no-pager` がローカルでも警告0で終了すること


Made with [Cursor](https://cursor.com)