### PR TITLE
feat: Google検索結果に表示されるサイトリンクを修正する

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,6 +8,13 @@ module ApplicationHelper
     stages#show
   ].freeze
 
+  # Google検索のサイトリンクとして案内するページ
+  SITELINK_PAGES = [
+    { name: "みんなが作ったタイムテーブル", path_method: :events_path },
+    { name: "利用規約", path_method: :terms_path },
+    { name: "プライバシーポリシー", path_method: :privacy_path }
+  ].freeze
+
   # 時刻を hh:mm 形式でフォーマットして返す
   def formatted_time(time)
     time&.strftime("%H:%M")
@@ -24,6 +31,39 @@ module ApplicationHelper
     else
       "#{request.base_url}#{request.path}"
     end
+  end
+
+  # サイトリンク対象ページの名称とパスを返す
+  def sitelink_pages
+    SITELINK_PAGES.map do |page|
+      { name: page[:name], path: public_send(page[:path_method]) }
+    end
+  end
+
+  # トップページ用のWebSite構造化データ（サイト名とサイトリンク対象ページ）
+  def website_structured_data
+    {
+      "@context" => "https://schema.org",
+      "@graph" => [
+        {
+          "@type" => "WebSite",
+          "name" => "みんなのタイムテーブル",
+          "alternateName" => [ "minnanotimetable" ],
+          "url" => root_url
+        },
+        {
+          "@type" => "ItemList",
+          "itemListElement" => sitelink_pages.map.with_index do |page, index|
+            {
+              "@type" => "SiteNavigationElement",
+              "position" => index + 1,
+              "name" => page[:name],
+              "url" => "#{request.base_url}#{page[:path]}"
+            }
+          end
+        }
+      ]
+    }
   end
 
   # 検索エンジンへインデックスさせないページかどうかを返す

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,6 +1,11 @@
 <%# 検索結果などに表示されるタイトルと説明 %>
 <% content_for :title, "みんなのタイムテーブル | 音楽フェス向けタイムテーブル作成サービス" %>
 <% content_for :description, "音楽フェスのWeb版タイムテーブルを簡単に作れるサービス。文字を入力するだけでタイムテーブルが出来上がる。スマホでもPCでも見やすい。" %>
+<% content_for :head do %>
+  <script type="application/ld+json">
+    <%= website_structured_data.to_json.html_safe %>
+  </script>
+<% end %>
 <div class="min-h-[calc(100svh-15rem)] flex flex-col justify-center items-center">
   <div class="w-full max-w-md flex flex-col justify-center items-center">
     <div class="w-full flex flex-col justify-center items-center mb-6">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -4,12 +4,10 @@
     <div class="mx-auto max-w-7xl px-4 py-8">
       <div class="flex flex-col items-center justify-between gap-4">
         <div class="flex items-center flex-wrap gap-8 text-sm">
-          <nav aria-label="主要ページ" class="flex items-center flex-wrap gap-8">
-            <% sitelink_pages.each do |page| %>
-              <%= link_to page[:name], page[:path],
-                  class: "text-gray-700 hover:text-gray-900 hover:underline" %>
-            <% end %>
-          </nav>
+          <%= link_to "利用規約", terms_path,
+              class: "text-gray-700 hover:text-gray-900 hover:underline" %>
+          <%= link_to "プライバシーポリシー", privacy_path,
+              class: "text-gray-700 hover:text-gray-900 hover:underline" %>
           <%= link_to "お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSfJBlhMJb4MWDX_xWlc2lel1P_X5zGTmySXlcWU7De_XtSJmw/viewform?usp=dialog",
                     class: "text-gray-700 hover:text-gray-900 hover:underline",
                     target: "_blank",

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -4,10 +4,12 @@
     <div class="mx-auto max-w-7xl px-4 py-8">
       <div class="flex flex-col items-center justify-between gap-4">
         <div class="flex items-center flex-wrap gap-8 text-sm">
-          <%= link_to "利用規約", terms_path,
-              class: "text-gray-700 hover:text-gray-900 hover:underline" %>
-          <%= link_to "プライバシーポリシー", privacy_path,
-              class: "text-gray-700 hover:text-gray-900 hover:underline" %>
+          <nav aria-label="主要ページ" class="flex items-center flex-wrap gap-8">
+            <% sitelink_pages.each do |page| %>
+              <%= link_to page[:name], page[:path],
+                  class: "text-gray-700 hover:text-gray-900 hover:underline" %>
+            <% end %>
+          </nav>
           <%= link_to "お問い合わせ", "https://docs.google.com/forms/d/e/1FAIpQLSfJBlhMJb4MWDX_xWlc2lel1P_X5zGTmySXlcWU7De_XtSJmw/viewform?usp=dialog",
                     class: "text-gray-700 hover:text-gray-900 hover:underline",
                     target: "_blank",

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -62,15 +62,12 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     end
   end
 
-  # フッターの主要ページ案内はサイトリンク対象の3ページに限定する
-  test "footer includes only sitelink pages in primary nav" do
+  # フッターにみんなが作ったタイムテーブルへのリンクは置かない
+  test "footer does not include all timetables link" do
     get "/"
-    assert_select "footer nav[aria-label=主要ページ]" do
-      assert_select "a", count: 3
-      assert_select "a[href=?]", events_path, text: "みんなが作ったタイムテーブル"
-      assert_select "a[href=?]", terms_path, text: "利用規約"
-      assert_select "a[href=?]", privacy_path, text: "プライバシーポリシー"
-    end
+    assert_select "footer a[href=?]", events_path, count: 0
+    assert_select "footer a[href=?]", terms_path, text: "利用規約"
+    assert_select "footer a[href=?]", privacy_path, text: "プライバシーポリシー"
   end
 
   # 名前が未確認のユーザーには名前変更モーダルが自動で読み込まれる

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -37,6 +37,42 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
     assert_select "html[lang=ja]"
   end
 
+  # トップページにサイト名とサイトリンク対象ページの構造化データがある
+  test "index includes website structured data with sitelinks" do
+    get "/"
+    assert_select "script[type='application/ld+json']" do |elements|
+      data = JSON.parse(elements.first.text)
+      website = data["@graph"].find { |node| node["@type"] == "WebSite" }
+      sitelinks = data["@graph"].find { |node| node["@type"] == "ItemList" }
+
+      assert_equal "みんなのタイムテーブル", website["name"]
+      assert_equal "http://www.example.com/", website["url"]
+      assert_equal(
+        [ "みんなが作ったタイムテーブル", "利用規約", "プライバシーポリシー" ],
+        sitelinks["itemListElement"].map { |item| item["name"] }
+      )
+      assert_equal(
+        [
+          "http://www.example.com/events",
+          "http://www.example.com/terms",
+          "http://www.example.com/privacy"
+        ],
+        sitelinks["itemListElement"].map { |item| item["url"] }
+      )
+    end
+  end
+
+  # フッターの主要ページ案内はサイトリンク対象の3ページに限定する
+  test "footer includes only sitelink pages in primary nav" do
+    get "/"
+    assert_select "footer nav[aria-label=主要ページ]" do
+      assert_select "a", count: 3
+      assert_select "a[href=?]", events_path, text: "みんなが作ったタイムテーブル"
+      assert_select "a[href=?]", terms_path, text: "利用規約"
+      assert_select "a[href=?]", privacy_path, text: "プライバシーポリシー"
+    end
+  end
+
   # 名前が未確認のユーザーには名前変更モーダルが自動で読み込まれる
   test "should load name confirmation modal when name is not confirmed" do
     sign_in users(:name_unconfirmed)

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -1,14 +1,25 @@
 require "test_helper"
 
 class StaticPagesControllerTest < ActionDispatch::IntegrationTest
-  test "should get terms" do
+  test "terms page does not include website structured data" do
     get terms_path
     assert_response :success
+    assert_select "script[type='application/ld+json']", count: 0
   end
 
   test "should get privacy" do
     get privacy_path
     assert_response :success
+  end
+
+  test "footer primary nav includes sitelink pages" do
+    get terms_path
+    assert_response :success
+    assert_select "footer nav[aria-label=主要ページ]" do
+      assert_select "a[href=?]", events_path, text: "みんなが作ったタイムテーブル"
+      assert_select "a[href=?]", terms_path, text: "利用規約"
+      assert_select "a[href=?]", privacy_path, text: "プライバシーポリシー"
+    end
   end
 
   test "footer includes status page link" do

--- a/test/controllers/static_pages_controller_test.rb
+++ b/test/controllers/static_pages_controller_test.rb
@@ -12,14 +12,12 @@ class StaticPagesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
-  test "footer primary nav includes sitelink pages" do
+  test "footer does not include all timetables link" do
     get terms_path
     assert_response :success
-    assert_select "footer nav[aria-label=主要ページ]" do
-      assert_select "a[href=?]", events_path, text: "みんなが作ったタイムテーブル"
-      assert_select "a[href=?]", terms_path, text: "利用規約"
-      assert_select "a[href=?]", privacy_path, text: "プライバシーポリシー"
-    end
+    assert_select "footer a[href=?]", events_path, count: 0
+    assert_select "footer a[href=?]", terms_path, text: "利用規約"
+    assert_select "footer a[href=?]", privacy_path, text: "プライバシーポリシー"
   end
 
   test "footer includes status page link" do


### PR DESCRIPTION
## Summary
- フッターの主要ページ案内を、サイトリンクとして出したい3ページ（みんなが作ったタイムテーブル・利用規約・プライバシーポリシー）に揃えた
- トップページにWebSite構造化データを追加し、同じ3ページをSiteNavigationElementとして明示した
- Googleはサイトリンクを直接指定できないため、内部リンクと構造化データで誘導する実装にしている

## Test plan
- [x] トップページのHTMLに `application/ld+json` があり、3ページの名称とURLが含まれている
- [x] フッターの「主要ページ」ナビに上記3ページだけが表示され、利用規約・プライバシーポリシーへのリンクが従来どおり動く
- [x] お問い合わせ・稼働状況などの外部リンクはフッターに残っている
- [x] マージ後、Googleが再クロールしてサイトリンクが更新されるまで数日〜数週間かかることがある

Closes: #496

Made with [Cursor](https://cursor.com)