### PR TITLE
feat: ご意見箱読み込み中にローディングマークを表示する

### DIFF
--- a/app/javascript/controllers/iframe_loading_controller.js
+++ b/app/javascript/controllers/iframe_loading_controller.js
@@ -1,0 +1,12 @@
+import { Controller } from "@hotwired/stimulus"
+
+// Connects to data-controller="iframe-loading"
+export default class extends Controller {
+  static targets = ["spinner"]
+
+  hide() {
+    if (!this.hasSpinnerTarget) return
+
+    this.spinnerTarget.classList.add("hidden")
+  }
+}

--- a/app/views/home/_feedback_form.html.erb
+++ b/app/views/home/_feedback_form.html.erb
@@ -1,11 +1,18 @@
-<section class="mb-12 w-full">
-  <div class="w-full overflow-hidden">
+<section class="mb-12 w-full" data-controller="iframe-loading">
+  <div class="relative w-full overflow-hidden">
+    <div data-iframe-loading-target="spinner"
+         class="absolute inset-0 z-10 flex items-center justify-center bg-white"
+         role="status"
+         aria-label="読み込み中">
+      <div class="h-8 w-8 border-4 border-gray-300 border-t-gray-800 rounded-full animate-spin" aria-hidden="true"></div>
+    </div>
     <iframe
       title="ご意見箱"
       src="https://docs.google.com/forms/d/e/1FAIpQLSdDYkoTm6JJ40NbK2gK2p-9p626HNShJdPssRoj1sG8KkKV_g/viewform?embedded=true"
       class="w-full border-0"
       style="min-height: 700px;"
-      loading="lazy">
+      loading="lazy"
+      data-action="load->iframe-loading#hide">
       読み込んでいます…
     </iframe>
   </div>

--- a/test/controllers/home_controller_test.rb
+++ b/test/controllers/home_controller_test.rb
@@ -14,9 +14,12 @@ class HomeControllerTest < ActionDispatch::IntegrationTest
   test "index includes embedded feedback google form when signed in" do
     sign_in users(:one)
     get "/"
+    assert_select "[data-controller=?]", "iframe-loading"
+    assert_select "[data-iframe-loading-target=?]", "spinner"
     assert_select "iframe[title=?]", "ご意見箱"
     assert_select "iframe[src=?]",
                   "https://docs.google.com/forms/d/e/1FAIpQLSdDYkoTm6JJ40NbK2gK2p-9p626HNShJdPssRoj1sG8KkKV_g/viewform?embedded=true"
+    assert_select "iframe[data-action=?]", "load->iframe-loading#hide"
   end
 
   # 未ログイン時はご意見箱を表示しない


### PR DESCRIPTION
## Summary
- ご意見箱（Googleフォーム埋め込み）の読み込み中に、既存UIと同じスピナーを表示する
- iframeのload後にスピナーを非表示にする

Closes: #493

## Test plan
- [x] ログインしてトップページを開く
- [x] ご意見箱が表示されるまで中央にローディングマークが出ること
- [x] フォーム読み込み完了後にローディングマークが消え、フォームが見えること
- [x] 未ログイン時はご意見箱もローディングも出ないこと


Made with [Cursor](https://cursor.com)