### PR TITLE
feat: 0時を過ぎる出演情報の日付を当日として表示する

### DIFF
--- a/app/controllers/performances_controller.rb
+++ b/app/controllers/performances_controller.rb
@@ -56,7 +56,7 @@ class PerformancesController < ApplicationController
   def edit
     # 出演者詳細ページから遷移した場合は出演者をセットする
     @performer = @performance.performer
-    @performance.start_time_hour   = @performance.start_time&.hour
+    @performance.start_time_hour   = FestivalTime.display_hour(@performance.start_time&.hour)
     @performance.start_time_minute = @performance.start_time&.min
   end
 
@@ -169,7 +169,7 @@ class PerformancesController < ApplicationController
     # 時刻をhourとminuteから作成
     def parse_time_from_hour_minute(hour, minute)
       return nil if hour.blank? || minute.blank?
-      Time.zone.local(2000, 1, 1, hour.to_i, minute.to_i)
+      Time.zone.local(2000, 1, 1, FestivalTime.clock_hour(hour), minute.to_i)
     end
 
     def restore_time_virtual_attributes

--- a/app/controllers/performers_controller.rb
+++ b/app/controllers/performers_controller.rb
@@ -13,7 +13,8 @@ class PerformersController < ApplicationController
   def index
     @performers = @event.performers
                         .order_by_name
-                        .includes(:performer_name_tag, performances: [ :day, { stage: :stage_name_tag } ])
+                        .includes(:performer_name_tag)
+                        .preload(performances: [ :day, { stage: :stage_name_tag } ])
     # お気に入り登録している出演者IDの配列を取得
     if user_signed_in?
       @favorite_performer_map = current_user.favorite_performer_map

--- a/app/controllers/timetable_images_controller.rb
+++ b/app/controllers/timetable_images_controller.rb
@@ -91,6 +91,6 @@ class TimetableImagesController < ApplicationController
         .where.not(start_time: nil, end_time: nil, duration: nil)
         .where(performers: { event_id: @event.id })
         .where(days: { date: @selected_date })
-        .order(:start_time)
+        .ordered_by_festival_start_time
     end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -17,7 +17,7 @@ module ApplicationHelper
 
   # 時刻を hh:mm 形式でフォーマットして返す
   def formatted_time(time)
-    time&.strftime("%H:%M")
+    FestivalTime.format_clock(time)
   end
 
   # 正規URLを返す（クエリパラメータは除く）。content_for :canonical で上書き可能

--- a/app/helpers/performances_helper.rb
+++ b/app/helpers/performances_helper.rb
@@ -1,8 +1,8 @@
 module PerformancesHelper
-  # 5分刻みの時刻スロットを生成
-  def time_select_options(hour_step: 1, minute_step: 5, start_hour: 0, end_hour: 24)
+  # 5分刻みの時刻スロットを生成（時は6時始まりで0時過ぎを後ろに回す）
+  def time_select_options(hour_step: 1, minute_step: 5)
     {
-      hours: (start_hour...end_hour).step(hour_step).map { |h| [ format("%02d", h), h ] },
+      hours: FestivalTime.hour_values.each_slice(hour_step).map(&:first).map { |h| [ format("%02d", h), h ] },
       minutes: (0...60).step(minute_step).map { |m| [ format("%02d", m), m ] }
     }
   end

--- a/app/helpers/performances_helper.rb
+++ b/app/helpers/performances_helper.rb
@@ -1,5 +1,5 @@
 module PerformancesHelper
-  # 5分刻みの時刻スロットを生成（時は6時始まりで0時過ぎを後ろに回す）
+  # 5分刻みの時刻スロットを生成（時は6時始まりで、0時過ぎは24〜29）
   def time_select_options(hour_step: 1, minute_step: 5)
     {
       hours: FestivalTime.hour_values.each_slice(hour_step).map(&:first).map { |h| [ format("%02d", h), h ] },

--- a/app/helpers/timetables_helper.rb
+++ b/app/helpers/timetables_helper.rb
@@ -7,11 +7,8 @@ module TimetablesHelper
 
   # タイムテーブル全体の高さを rem で返す（1時間単位）
   def timetable_height_rem(performances)
-    start_hour = performances.min_by(&:start_time).start_time.hour
-    end_time   = performances.max_by(&:end_time).end_time
-    # 終了時刻は「次の時間」に切り上げ
-    end_hour = end_time.min.zero? ? end_time.hour : end_time.hour + 1
-    total_hours = end_hour - start_hour
+    start_minutes, end_ceil_minutes = festival_timetable_span(performances)
+    total_hours = (end_ceil_minutes - start_minutes) / 60.0
     total_hours * TIMETABLE_REM_PER_HOUR
   end
 
@@ -19,16 +16,15 @@ module TimetablesHelper
   def timetable_start_minute
     # 最初の1回だけ計算して、1リクエスト中は結果を使い回す
     @timetable_start_minute ||= begin
-      earliest = @performances.min_by(&:start_time).start_time
-      # タイムテーブル描画開始位置を正時にするため、minuteを切り捨てる
-      earliest.hour * 60
+      earliest = earliest_festival_performance(@performances)
+      FestivalTime.floor_hour_minutes(earliest.start_time)
     end
   end
 
   # performance の開始位置の top を rem で返す
   def performance_top_rem(performance)
     timetable_start_min = timetable_start_minute
-    start_min = performance.start_time.hour * 60 + performance.start_time.min
+    start_min = FestivalTime.to_minutes(performance.start_time)
     diff_min  = start_min - timetable_start_min
     rem_per_min  = TIMETABLE_REM_PER_HOUR / 60.0
     instead_of_margin = 0.05 # マージンの代わり
@@ -37,17 +33,8 @@ module TimetablesHelper
 
   # タイムテーブル用の時刻スロット配列を生成
   def time_slots_for_timetable(performances)
-    start_time = performances.min_by(&:start_time).start_time
-    end_time   = performances.max_by(&:end_time).end_time
-    start_hour = start_time.hour
-    # 終了時刻が00分なら、その時間は表示しない
-    last_hour =
-      if end_time.min.zero?
-        end_time.hour - 1
-      else
-        end_time.hour
-      end
-    (start_hour..last_hour).to_a
+    start_minutes, end_ceil_minutes = festival_timetable_span(performances)
+    FestivalTime.hour_slots(start_minutes, end_ceil_minutes)
   end
 
   # 下余白のCSS変数を:rootへ定義するstyleタグ
@@ -69,9 +56,8 @@ module TimetablesHelper
 
   # 下余白の開始位置に表示する正時（タイムテーブル末尾の次の時刻）
   def timetable_bottom_spacer_hour(performances)
-    end_time = performances.max_by(&:end_time).end_time
-    end_hour = end_time.min.zero? ? end_time.hour : end_time.hour + 1
-    end_hour % 24
+    _start_minutes, end_ceil_minutes = festival_timetable_span(performances)
+    FestivalTime.hour_from_minutes(end_ceil_minutes)
   end
 
   # performance の高さを rem で返す
@@ -135,4 +121,27 @@ module TimetablesHelper
 
     [ min_capture_width, content_width ].max
   end
+
+  private
+    # フェス分で最も早い出演
+    def earliest_festival_performance(performances)
+      performances.min_by { |performance| FestivalTime.to_minutes(performance.start_time) }
+    end
+
+    # フェス分で最も遅く終わる出演
+    def latest_festival_performance(performances)
+      performances.max_by { |performance|
+        FestivalTime.end_minutes(performance.start_time, performance.end_time)
+      }
+    end
+
+    # タイムテーブルの開始正時と終了正時（排他）をフェス分で返す
+    def festival_timetable_span(performances)
+      earliest = earliest_festival_performance(performances)
+      latest = latest_festival_performance(performances)
+      [
+        FestivalTime.floor_hour_minutes(earliest.start_time),
+        FestivalTime.ceil_hour_minutes(latest.start_time, latest.end_time)
+      ]
+    end
 end

--- a/app/models/festival_time.rb
+++ b/app/models/festival_time.rb
@@ -12,16 +12,13 @@ class FestivalTime
     minutes < DAY_START_MINUTES ? minutes + MINUTES_PER_DAY : minutes
   end
 
-  # 終了時刻のフェス分。開始より前、または同じ時計時刻（24時間以上）なら翌日扱いとして24時間を足す
+  # 終了時刻のフェス分。開始より前なら翌日扱いとして24時間を足す
   def self.end_minutes(start_time, end_time)
     start_m = to_minutes(start_time)
     end_m = to_minutes(end_time)
     return if start_m.nil? || end_m.nil?
 
-    elapsed = ((end_time - start_time) / 60).to_i
-    return start_m + elapsed if elapsed >= MINUTES_PER_DAY
-
-    end_m += MINUTES_PER_DAY if end_m <= start_m
+    end_m += MINUTES_PER_DAY if end_m < start_m
     end_m
   end
 

--- a/app/models/festival_time.rb
+++ b/app/models/festival_time.rb
@@ -12,13 +12,16 @@ class FestivalTime
     minutes < DAY_START_MINUTES ? minutes + MINUTES_PER_DAY : minutes
   end
 
-  # 終了時刻のフェス分。開始より前なら翌日扱いとして24時間を足す
+  # 終了時刻のフェス分。開始より前、または同じ時計時刻（24時間以上）なら翌日扱いとして24時間を足す
   def self.end_minutes(start_time, end_time)
     start_m = to_minutes(start_time)
     end_m = to_minutes(end_time)
     return if start_m.nil? || end_m.nil?
 
-    end_m += MINUTES_PER_DAY if end_m < start_m
+    elapsed = ((end_time - start_time) / 60).to_i
+    return start_m + elapsed if elapsed >= MINUTES_PER_DAY
+
+    end_m += MINUTES_PER_DAY if end_m <= start_m
     end_m
   end
 

--- a/app/models/festival_time.rb
+++ b/app/models/festival_time.rb
@@ -39,9 +39,31 @@ class FestivalTime
     minutes + (60 - (minutes % 60))
   end
 
-  # フェス分から表示用の時（0-23）を返す
+  # フェス分から表示用の時を返す（0時過ぎは24〜29）
   def self.hour_from_minutes(minutes)
-    (minutes / 60) % 24
+    minutes / 60
+  end
+
+  # 時計の時を表示用の時に変換する（0〜5 → 24〜29）
+  def self.display_hour(hour)
+    return if hour.nil?
+
+    hour < DAY_START_HOUR ? hour + 24 : hour
+  end
+
+  # 表示用の時を時計の時に戻す（24〜29 → 0〜5）
+  def self.clock_hour(hour)
+    return if hour.blank?
+
+    hour = hour.to_i
+    hour >= 24 ? hour - 24 : hour
+  end
+
+  # 6時未満は +24 した hh:mm を返す
+  def self.format_clock(time)
+    return if time.blank?
+
+    format("%02d:%02d", display_hour(time.hour), time.min)
   end
 
   # 開始正時から終了正時の直前まで、ラップする時刻スロットを返す
@@ -56,9 +78,9 @@ class FestivalTime
     hours
   end
 
-  # フォームの時セレクト（6〜23 のあと 0〜5）
+  # フォームの時セレクト（6〜23 のあと 24〜29）
   def self.hour_values
-    (DAY_START_HOUR...24).to_a + (0...DAY_START_HOUR).to_a
+    (DAY_START_HOUR...24).to_a + (24...(24 + DAY_START_HOUR)).to_a
   end
 
   # 6時未満を後ろに回す ORDER BY 用SQL（SQLite / PostgreSQL 両対応）

--- a/app/models/festival_time.rb
+++ b/app/models/festival_time.rb
@@ -1,0 +1,74 @@
+# 開催日の日付境界（午前6時）を基準に、出演時刻をフェス日内の分数へ変換する
+class FestivalTime
+  DAY_START_HOUR = 6
+  DAY_START_MINUTES = DAY_START_HOUR * 60
+  MINUTES_PER_DAY = 24 * 60
+
+  # 時計時刻をフェス日内の分に変換する（6:00=360, 0:00=1440, 5:00=1740）
+  def self.to_minutes(time)
+    return if time.blank?
+
+    minutes = time.hour * 60 + time.min
+    minutes < DAY_START_MINUTES ? minutes + MINUTES_PER_DAY : minutes
+  end
+
+  # 終了時刻のフェス分。開始より前なら翌日扱いとして24時間を足す
+  def self.end_minutes(start_time, end_time)
+    start_m = to_minutes(start_time)
+    end_m = to_minutes(end_time)
+    return if start_m.nil? || end_m.nil?
+
+    end_m += MINUTES_PER_DAY if end_m < start_m
+    end_m
+  end
+
+  # 開始時刻を正時に切り捨てたフェス分
+  def self.floor_hour_minutes(time)
+    minutes = to_minutes(time)
+    return if minutes.nil?
+
+    minutes - (minutes % 60)
+  end
+
+  # 終了時刻を次の正時に切り上げたフェス分（ちょうど正時ならそのまま）
+  def self.ceil_hour_minutes(start_time, end_time)
+    minutes = end_minutes(start_time, end_time)
+    return if minutes.nil?
+    return minutes if end_time.min.zero?
+
+    minutes + (60 - (minutes % 60))
+  end
+
+  # フェス分から表示用の時（0-23）を返す
+  def self.hour_from_minutes(minutes)
+    (minutes / 60) % 24
+  end
+
+  # 開始正時から終了正時の直前まで、ラップする時刻スロットを返す
+  def self.hour_slots(start_minutes, end_ceil_minutes)
+    last_minutes = end_ceil_minutes - 60
+    hours = []
+    minutes = start_minutes
+    while minutes <= last_minutes
+      hours << hour_from_minutes(minutes)
+      minutes += 60
+    end
+    hours
+  end
+
+  # フォームの時セレクト（6〜23 のあと 0〜5）
+  def self.hour_values
+    (DAY_START_HOUR...24).to_a + (0...DAY_START_HOUR).to_a
+  end
+
+  # 6時未満を後ろに回す ORDER BY 用SQL（SQLite / PostgreSQL 両対応）
+  def self.wrap_order_sql(column = "performances.start_time")
+    hour_sql =
+      if ApplicationRecord.connection.adapter_name == "PostgreSQL"
+        "EXTRACT(HOUR FROM #{column})"
+      else
+        "CAST(strftime('%H', #{column}) AS INTEGER)"
+      end
+    Arel.sql("CASE WHEN #{hour_sql} < #{DAY_START_HOUR} THEN 1 ELSE 0 END")
+  end
+end

--- a/app/models/festival_time.rb
+++ b/app/models/festival_time.rb
@@ -84,13 +84,12 @@ class FestivalTime
   end
 
   # 6時未満を後ろに回す ORDER BY 用SQL（SQLite / PostgreSQL 両対応）
-  def self.wrap_order_sql(column = "performances.start_time")
-    hour_sql =
-      if ApplicationRecord.connection.adapter_name == "PostgreSQL"
-        "EXTRACT(HOUR FROM #{column})"
-      else
-        "CAST(strftime('%H', #{column}) AS INTEGER)"
-      end
-    Arel.sql("CASE WHEN #{hour_sql} < #{DAY_START_HOUR} THEN 1 ELSE 0 END")
+  # 列名や境界時刻を変数埋め込みしない（Brakeman の SQL Injection 警告を避ける）
+  def self.wrap_order_sql
+    if ApplicationRecord.connection.adapter_name == "PostgreSQL"
+      Arel.sql("CASE WHEN EXTRACT(HOUR FROM performances.start_time) < 6 THEN 1 ELSE 0 END")
+    else
+      Arel.sql("CASE WHEN CAST(strftime('%H', performances.start_time) AS INTEGER) < 6 THEN 1 ELSE 0 END")
+    end
   end
 end

--- a/app/models/performance.rb
+++ b/app/models/performance.rb
@@ -11,6 +11,7 @@ class Performance < ApplicationRecord
   belongs_to :stage, optional: true
 
   validate :duration_more_five, if: -> { start_time && duration }
+  validate :duration_at_most_one_hundred_twenty, if: -> { start_time && duration }
 
   # 5分刻みであることをチェック
   validate :time_must_be_5min_step
@@ -120,6 +121,11 @@ class Performance < ApplicationRecord
   # durationが5以上かチェック
   def duration_more_five
     errors.add(:duration, "は5以上で入力してください") if duration < 5
+  end
+
+  # セレクトの上限（120分）を超えていないかチェック
+  def duration_at_most_one_hundred_twenty
+    errors.add(:duration, "は120以下で入力してください") if duration > 120
   end
 
   # 5分刻みであることをチェック

--- a/app/models/performance.rb
+++ b/app/models/performance.rb
@@ -28,15 +28,20 @@ class Performance < ApplicationRecord
       .where(performers: { event_id: event.id })
   }
 
+  # 6時起点の開催日内の開始時刻順
+  scope :ordered_by_festival_start_time, -> {
+    order(FestivalTime.wrap_order_sql, "performances.start_time ASC")
+  }
+
   # 開催日と開始時刻順で並べ、必要な関連も事前ロードするスコープ
   scope :ordered_for_performer_detail, -> {
     left_joins(:day)
       .includes(:day, stage: :stage_name_tag)
       .order(
         Arel.sql("days.date IS NULL ASC"), # dayあり → dayなし の順
-        "days.date ASC",
-        "performances.start_time ASC"
+        "days.date ASC"
       )
+      .ordered_by_festival_start_time
   }
 
   # タイムテーブル描画に必要な情報がすべて揃った performance を取得するスコープ
@@ -50,7 +55,7 @@ class Performance < ApplicationRecord
     .where(performers: { event_id: event.id })
     .where(days: { date: date })
     .includes(performer: :performer_name_tag)
-    .order(:start_time)
+    .ordered_by_festival_start_time
   }
 
   # ==== タイムテーブル表示用メソッド ====
@@ -65,9 +70,19 @@ class Performance < ApplicationRecord
     start_time.min
   end
 
-  # 開始時刻を分単位のキーに変換（並び・位置計算用）
+  # 開始時刻をフェス日内の分単位のキーに変換（並び・位置計算用）
   def start_key
-    start_time.hour * 60 + start_time.min
+    festival_start_minutes
+  end
+
+  # 開始時刻のフェス分
+  def festival_start_minutes
+    FestivalTime.to_minutes(start_time)
+  end
+
+  # 終了時刻のフェス分（日付またぎを含む）
+  def festival_end_minutes
+    FestivalTime.end_minutes(start_time, end_time)
   end
 
   # hh:mm 形式の開始時刻
@@ -146,19 +161,21 @@ class Performance < ApplicationRecord
     return unless performer.present?
     return if start_time.blank? || end_time.blank?
     return if day.blank? || stage.blank?
-    overlapping = Performance
+    others = Performance
       .joins(:performer)
       .where(performers: { event_id: performer.event_id })
       .where(day_id: day_id, stage_id: stage_id)
       .where.not(id: id)
-      .where(
-        "start_time < ? AND end_time > ?",
-        end_time,
-        start_time
-      )
+      .where.not(start_time: nil, end_time: nil)
 
-    if overlapping.exists?
+    if others.any? { |other| festival_ranges_overlap?(other) }
       errors.add(:base, "同じ時間帯に他の出演情報が存在します")
     end
+  end
+
+  # フェス分の半開区間で重なっているか
+  def festival_ranges_overlap?(other)
+    festival_start_minutes < other.festival_end_minutes &&
+      festival_end_minutes > other.festival_start_minutes
   end
 end

--- a/app/models/performance.rb
+++ b/app/models/performance.rb
@@ -35,12 +35,13 @@ class Performance < ApplicationRecord
   }
 
   # 開催日順のあと、6時起点の開始時刻順
+  # daysをJOINすると、Eventがperformers経由でperformancesをJOINしたときに
+  # daysテーブル名が衝突するため、相関サブクエリで日付を参照する
   scope :ordered_by_festival_day_and_time, -> {
-    left_joins(:day)
-      .order(
-        Arel.sql("days.date IS NULL ASC"), # dayあり → dayなし の順
-        "days.date ASC"
-      )
+    order(
+      Arel.sql("(SELECT days.date FROM days WHERE days.id = performances.day_id) IS NULL ASC"),
+      Arel.sql("(SELECT days.date FROM days WHERE days.id = performances.day_id) ASC")
+    )
       .ordered_by_festival_start_time
   }
 

--- a/app/models/performance.rb
+++ b/app/models/performance.rb
@@ -87,7 +87,7 @@ class Performance < ApplicationRecord
 
   # hh:mm 形式の開始時刻
   def formatted_start_time
-    format("%02d:%02d", start_time.hour, start_time.min)
+    FestivalTime.format_clock(start_time)
   end
 
   # 5分単位に変換した出演時間

--- a/app/models/performance.rb
+++ b/app/models/performance.rb
@@ -34,15 +34,19 @@ class Performance < ApplicationRecord
     order(FestivalTime.wrap_order_sql, "performances.start_time ASC")
   }
 
-  # 開催日と開始時刻順で並べ、必要な関連も事前ロードするスコープ
-  scope :ordered_for_performer_detail, -> {
+  # 開催日順のあと、6時起点の開始時刻順
+  scope :ordered_by_festival_day_and_time, -> {
     left_joins(:day)
-      .includes(:day, stage: :stage_name_tag)
       .order(
         Arel.sql("days.date IS NULL ASC"), # dayあり → dayなし の順
         "days.date ASC"
       )
       .ordered_by_festival_start_time
+  }
+
+  # 開催日と開始時刻順で並べ、必要な関連も事前ロードするスコープ
+  scope :ordered_for_performer_detail, -> {
+    ordered_by_festival_day_and_time.includes(:day, stage: :stage_name_tag)
   }
 
   # タイムテーブル描画に必要な情報がすべて揃った performance を取得するスコープ

--- a/app/models/performer.rb
+++ b/app/models/performer.rb
@@ -3,7 +3,8 @@ class Performer < ApplicationRecord
   belongs_to :performer_name_tag
 
   # 出演者を削除すると、紐づいている出演情報も全て削除される
-  has_many :performances, dependent: :destroy
+  has_many :performances, -> { merge(Performance.ordered_by_festival_day_and_time) },
+           dependent: :destroy
 
   # nested attributes を許可（フォームで fields_for を使うため）
   accepts_nested_attributes_for :performer_name_tag, update_only: false

--- a/app/services/timetable_creator.rb
+++ b/app/services/timetable_creator.rb
@@ -74,7 +74,7 @@ class TimetableCreator
         start_time: performance_data["start_time"],
         duration: temp_duration
       )
-    end.sort_by(&:start_time)
+    end.sort_by { |performance| FestivalTime.to_minutes(performance.start_time) }
   end
 
   # durationを計算
@@ -92,7 +92,8 @@ class TimetableCreator
 
   # duration計算ロジック
   def calc_duration(current_time, next_time)
-    minutes = ((next_time - current_time) / 60).to_i
+    minutes = FestivalTime.to_minutes(next_time) - FestivalTime.to_minutes(current_time)
+    minutes += FestivalTime::MINUTES_PER_DAY if minutes.negative?
     duration = minutes / 2
     duration = (duration / 5) * 5
     duration = duration.clamp(5, 60)

--- a/app/views/performers/_performances.html.erb
+++ b/app/views/performers/_performances.html.erb
@@ -12,7 +12,7 @@
               出演日：未定
             <% end %>
             <% if performance.start_time.present? && performance.end_time.present? %>
-              <%= "#{performance.start_time.strftime("%H:%M")}~#{performance.end_time.strftime("%H:%M")}" %>
+              <%= "#{formatted_time(performance.start_time)}~#{formatted_time(performance.end_time)}" %>
             <% else %>
               時刻：未定
             <% end %>

--- a/app/views/performers/index.html.erb
+++ b/app/views/performers/index.html.erb
@@ -33,7 +33,7 @@
                 </p>
                 <p class="text-sm">
                   <% if performance.start_time.present? && performance.end_time.present? %>
-                    <%= "#{performance.start_time.strftime("%H:%M")}~" %>
+                    <%= "#{formatted_time(performance.start_time)}~" %>
                   <% else %>
                     時刻：未定
                   <% end %>

--- a/test/controllers/performances_controller_test.rb
+++ b/test/controllers/performances_controller_test.rb
@@ -49,6 +49,26 @@ class PerformancesControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to show_timetable_path(@event.event_key, d: day.date)
   end
 
+  # 表示用の25時は時計の1時として保存される
+  test "should create overnight performance from display hour 25" do
+    day = @event.days.first
+    assert_difference("Performance.for_event(@event).count") do
+      post event_performances_path(@event.event_key), params: {
+        performance: {
+          performer_id: @event.performers.first.id,
+          day_id: day.id,
+          stage_id: @event.stages.second.id,
+          start_time_hour: "25",
+          start_time_minute: "00",
+          duration: 30
+        }
+      }
+    end
+    performance = Performance.for_event(@event).order(:id).last
+    assert_equal 1, performance.start_time.hour
+    assert_equal 0, performance.start_time.min
+  end
+
   # 出演者名だけで出演情報を作成でき、日付を指定していないためdパラメータ無しでリダイレクトされる
   test "should create performance only with performer" do
     assert_difference("Performance.for_event(@event).count") do
@@ -106,6 +126,20 @@ class PerformancesControllerTest < ActionDispatch::IntegrationTest
   test "should get edit" do
     get edit_event_performance_url(@event.event_key, @performance)
     assert_response :success
+  end
+
+  # 0時過ぎの出演は編集フォームで24時台が選択される
+  test "should select display hour 25 when editing overnight performance" do
+    performance = Performance.create!(
+      performer: @event.performers.first,
+      day: @event.days.first,
+      stage: @event.stages.second,
+      start_time: Time.zone.parse("01:00"),
+      duration: 30
+    )
+    get edit_event_performance_url(@event.event_key, performance)
+    assert_response :success
+    assert_select 'select[name="performance[start_time_hour]"] option[selected][value="25"]'
   end
 
   # 他者の出演情報編集ページはアクセスできない

--- a/test/controllers/performers_controller_test.rb
+++ b/test/controllers/performers_controller_test.rb
@@ -58,6 +58,28 @@ class PerformersControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  # 出演者カードの先頭出演は6時起点の順（22:00が01:00より先）
+  test "index card shows earliest festival performance first" do
+    performer = create_overnight_performer
+
+    get event_performers_url(@event.event_key)
+    assert_response :success
+    assert_select "a[href=?]", event_performer_path(@event.event_key, performer) do
+      assert_select "p", text: /22:00~/
+      assert_select "p", text: /25:00~/, count: 0
+    end
+  end
+
+  # 出演者詳細の出演一覧も6時起点の順
+  test "show lists performances in festival time order" do
+    performer = create_overnight_performer
+
+    get event_performer_url(@event.event_key, performer)
+    assert_response :success
+    body = response.body
+    assert_operator body.index("22:00~"), :<, body.index("25:00~")
+  end
+
   # 出演者追加ページ
   test "should get new" do
     get new_event_performer_url(@event.event_key)
@@ -282,4 +304,26 @@ class PerformersControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :not_found
   end
+
+  private
+    def create_overnight_performer
+      tag = PerformerNameTag.create!(name: "オールナイト出演者")
+      performer = @event.performers.create!(performer_name_tag: tag)
+      day = @event.days.first
+      Performance.create!(
+        performer: performer,
+        day: day,
+        stage: @event.stages.first,
+        start_time: Time.zone.parse("01:00"),
+        duration: 30
+      )
+      Performance.create!(
+        performer: performer,
+        day: day,
+        stage: @event.stages.second,
+        start_time: Time.zone.parse("22:00"),
+        duration: 30
+      )
+      performer
+    end
 end

--- a/test/helpers/performances_helper_test.rb
+++ b/test/helpers/performances_helper_test.rb
@@ -1,0 +1,12 @@
+require "test_helper"
+
+class PerformancesHelperTest < ActionView::TestCase
+  test "hour select options start at 6 and end at 5" do
+    hours = time_select_options[:hours].map(&:last)
+
+    assert_equal "06", time_select_options[:hours].first.first
+    assert_equal 6, hours.first
+    assert_equal 5, hours.last
+    assert_equal (6..23).to_a + (0..5).to_a, hours
+  end
+end

--- a/test/helpers/performances_helper_test.rb
+++ b/test/helpers/performances_helper_test.rb
@@ -1,12 +1,13 @@
 require "test_helper"
 
 class PerformancesHelperTest < ActionView::TestCase
-  test "hour select options start at 6 and end at 5" do
+  test "hour select options start at 6 and end at 29" do
     hours = time_select_options[:hours].map(&:last)
 
     assert_equal "06", time_select_options[:hours].first.first
+    assert_equal "29", time_select_options[:hours].last.first
     assert_equal 6, hours.first
-    assert_equal 5, hours.last
-    assert_equal (6..23).to_a + (0..5).to_a, hours
+    assert_equal 29, hours.last
+    assert_equal (6..23).to_a + (24..29).to_a, hours
   end
 end

--- a/test/helpers/timetables_helper_test.rb
+++ b/test/helpers/timetables_helper_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+require "ostruct"
+
+class TimetablesHelperTest < ActionView::TestCase
+  test "builds daytime hour slots and height from 10:00 to 22:00" do
+    performances = [
+      performance_at("10:00", duration: 60),
+      performance_at("21:00", duration: 60)
+    ]
+
+    assert_equal (10..21).to_a, time_slots_for_timetable(performances)
+    assert_equal 12 * TimetablesHelper::TIMETABLE_REM_PER_HOUR, timetable_height_rem(performances)
+    assert_equal 22, timetable_bottom_spacer_hour(performances)
+  end
+
+  test "wraps overnight hour slots from 22:00 to 02:00" do
+    performances = [
+      performance_at("22:00", duration: 60),
+      performance_at("01:00", duration: 30)
+    ]
+
+    assert_equal [ 22, 23, 0, 1 ], time_slots_for_timetable(performances)
+    assert_equal 4 * TimetablesHelper::TIMETABLE_REM_PER_HOUR, timetable_height_rem(performances)
+    assert_equal 2, timetable_bottom_spacer_hour(performances)
+  end
+
+  test "places overnight performance below evening on the timetable" do
+    evening = performance_at("22:00", duration: 60)
+    overnight = performance_at("01:00", duration: 30)
+    @performances = [ evening, overnight ]
+
+    overnight_top = performance_top_rem(overnight)
+    evening_top = performance_top_rem(evening)
+
+    assert overnight_top > evening_top
+    assert_operator overnight_top, :>, 0
+  end
+
+  private
+    def performance_at(start_hm, duration:)
+      start_time = Time.zone.parse(start_hm)
+      OpenStruct.new(
+        start_time: start_time,
+        end_time: start_time + duration.minutes,
+        duration: duration
+      )
+    end
+end

--- a/test/helpers/timetables_helper_test.rb
+++ b/test/helpers/timetables_helper_test.rb
@@ -19,9 +19,9 @@ class TimetablesHelperTest < ActionView::TestCase
       performance_at("01:00", duration: 30)
     ]
 
-    assert_equal [ 22, 23, 0, 1 ], time_slots_for_timetable(performances)
+    assert_equal [ 22, 23, 24, 25 ], time_slots_for_timetable(performances)
     assert_equal 4 * TimetablesHelper::TIMETABLE_REM_PER_HOUR, timetable_height_rem(performances)
-    assert_equal 2, timetable_bottom_spacer_hour(performances)
+    assert_equal 26, timetable_bottom_spacer_hour(performances)
   end
 
   test "places overnight performance below evening on the timetable" do

--- a/test/helpers/timetables_helper_test.rb
+++ b/test/helpers/timetables_helper_test.rb
@@ -1,7 +1,8 @@
 require "test_helper"
-require "ostruct"
 
 class TimetablesHelperTest < ActionView::TestCase
+  HelperPerformance = Data.define(:start_time, :end_time, :duration)
+
   test "builds daytime hour slots and height from 10:00 to 22:00" do
     performances = [
       performance_at("10:00", duration: 60),
@@ -39,7 +40,7 @@ class TimetablesHelperTest < ActionView::TestCase
   private
     def performance_at(start_hm, duration:)
       start_time = Time.zone.parse(start_hm)
-      OpenStruct.new(
+      HelperPerformance.new(
         start_time: start_time,
         end_time: start_time + duration.minutes,
         duration: duration

--- a/test/models/festival_time_test.rb
+++ b/test/models/festival_time_test.rb
@@ -1,0 +1,56 @@
+require "test_helper"
+
+class FestivalTimeTest < ActiveSupport::TestCase
+  test "converts clock time to festival minutes with 6:00 as day start" do
+    assert_equal 6 * 60, FestivalTime.to_minutes(Time.zone.parse("06:00"))
+    assert_equal 23 * 60, FestivalTime.to_minutes(Time.zone.parse("23:00"))
+    assert_equal 24 * 60, FestivalTime.to_minutes(Time.zone.parse("00:00"))
+    assert_equal 24 * 60 + 5 * 60, FestivalTime.to_minutes(Time.zone.parse("05:00"))
+    assert_equal 24 * 60 + 5 * 60 + 59, FestivalTime.to_minutes(Time.zone.parse("05:59"))
+  end
+
+  test "returns nil when time is blank" do
+    assert_nil FestivalTime.to_minutes(nil)
+    assert_nil FestivalTime.end_minutes(nil, Time.zone.parse("01:00"))
+  end
+
+  test "adds 24 hours when end time wraps past midnight or 6:00" do
+    assert_equal 25 * 60, FestivalTime.end_minutes(
+      Time.zone.parse("23:00"),
+      Time.zone.parse("01:00")
+    )
+    assert_equal 6 * 60 + 20 + 24 * 60, FestivalTime.end_minutes(
+      Time.zone.parse("05:50"),
+      Time.zone.parse("06:20")
+    )
+    assert_equal 10 * 60 + 30, FestivalTime.end_minutes(
+      Time.zone.parse("10:00"),
+      Time.zone.parse("10:30")
+    )
+  end
+
+  test "floors and ceils festival minutes to the hour" do
+    assert_equal 22 * 60, FestivalTime.floor_hour_minutes(Time.zone.parse("22:30"))
+    assert_equal 25 * 60, FestivalTime.floor_hour_minutes(Time.zone.parse("01:30"))
+    assert_equal 22 * 60, FestivalTime.ceil_hour_minutes(
+      Time.zone.parse("21:00"),
+      Time.zone.parse("22:00")
+    )
+    assert_equal 26 * 60, FestivalTime.ceil_hour_minutes(
+      Time.zone.parse("01:00"),
+      Time.zone.parse("01:30")
+    )
+  end
+
+  test "builds wrapping hour slots from start to exclusive end" do
+    assert_equal [ 10, 11, 12 ], FestivalTime.hour_slots(10 * 60, 13 * 60)
+    assert_equal [ 22, 23, 0, 1 ], FestivalTime.hour_slots(22 * 60, 26 * 60)
+  end
+
+  test "hour select values start at 6 and end at 5" do
+    hours = FestivalTime.hour_values
+    assert_equal 6, hours.first
+    assert_equal 5, hours.last
+    assert_equal (6..23).to_a + (0..5).to_a, hours
+  end
+end

--- a/test/models/festival_time_test.rb
+++ b/test/models/festival_time_test.rb
@@ -44,13 +44,31 @@ class FestivalTimeTest < ActiveSupport::TestCase
 
   test "builds wrapping hour slots from start to exclusive end" do
     assert_equal [ 10, 11, 12 ], FestivalTime.hour_slots(10 * 60, 13 * 60)
-    assert_equal [ 22, 23, 0, 1 ], FestivalTime.hour_slots(22 * 60, 26 * 60)
+    assert_equal [ 22, 23, 24, 25 ], FestivalTime.hour_slots(22 * 60, 26 * 60)
   end
 
-  test "hour select values start at 6 and end at 5" do
+  test "hour select values start at 6 and end at 29" do
     hours = FestivalTime.hour_values
     assert_equal 6, hours.first
-    assert_equal 5, hours.last
-    assert_equal (6..23).to_a + (0..5).to_a, hours
+    assert_equal 29, hours.last
+    assert_equal (6..23).to_a + (24..29).to_a, hours
+  end
+
+  test "formats times before 6:00 as 24:00 through 29:59" do
+    assert_equal "06:00", FestivalTime.format_clock(Time.zone.parse("06:00"))
+    assert_equal "23:00", FestivalTime.format_clock(Time.zone.parse("23:00"))
+    assert_equal "24:00", FestivalTime.format_clock(Time.zone.parse("00:00"))
+    assert_equal "25:30", FestivalTime.format_clock(Time.zone.parse("01:30"))
+    assert_equal "29:59", FestivalTime.format_clock(Time.zone.parse("05:59"))
+    assert_nil FestivalTime.format_clock(nil)
+  end
+
+  test "converts between clock hours and display hours" do
+    assert_equal 24, FestivalTime.display_hour(0)
+    assert_equal 29, FestivalTime.display_hour(5)
+    assert_equal 6, FestivalTime.display_hour(6)
+    assert_equal 0, FestivalTime.clock_hour(24)
+    assert_equal 5, FestivalTime.clock_hour(29)
+    assert_equal 10, FestivalTime.clock_hour(10)
   end
 end

--- a/test/models/festival_time_test.rb
+++ b/test/models/festival_time_test.rb
@@ -29,15 +29,6 @@ class FestivalTimeTest < ActiveSupport::TestCase
     )
   end
 
-  test "treats equal clock times as a 24-hour interval" do
-    start_time = Time.zone.parse("10:00")
-    next_day_end = start_time + FestivalTime::MINUTES_PER_DAY.minutes
-    same_clock_end = Time.zone.parse("10:00")
-
-    assert_equal 10 * 60 + FestivalTime::MINUTES_PER_DAY, FestivalTime.end_minutes(start_time, next_day_end)
-    assert_equal 10 * 60 + FestivalTime::MINUTES_PER_DAY, FestivalTime.end_minutes(start_time, same_clock_end)
-  end
-
   test "floors and ceils festival minutes to the hour" do
     assert_equal 22 * 60, FestivalTime.floor_hour_minutes(Time.zone.parse("22:30"))
     assert_equal 25 * 60, FestivalTime.floor_hour_minutes(Time.zone.parse("01:30"))

--- a/test/models/festival_time_test.rb
+++ b/test/models/festival_time_test.rb
@@ -29,6 +29,15 @@ class FestivalTimeTest < ActiveSupport::TestCase
     )
   end
 
+  test "treats equal clock times as a 24-hour interval" do
+    start_time = Time.zone.parse("10:00")
+    next_day_end = start_time + FestivalTime::MINUTES_PER_DAY.minutes
+    same_clock_end = Time.zone.parse("10:00")
+
+    assert_equal 10 * 60 + FestivalTime::MINUTES_PER_DAY, FestivalTime.end_minutes(start_time, next_day_end)
+    assert_equal 10 * 60 + FestivalTime::MINUTES_PER_DAY, FestivalTime.end_minutes(start_time, same_clock_end)
+  end
+
   test "floors and ceils festival minutes to the hour" do
     assert_equal 22 * 60, FestivalTime.floor_hour_minutes(Time.zone.parse("22:30"))
     assert_equal 25 * 60, FestivalTime.floor_hour_minutes(Time.zone.parse("01:30"))

--- a/test/models/performance_test.rb
+++ b/test/models/performance_test.rb
@@ -90,6 +90,18 @@ class PerformanceTest < ActiveSupport::TestCase
     assert_includes performance.errors[:duration], "は5以上で入力してください"
   end
 
+  # durationが120より大きい場合はエラー
+  test "is invalid when duration is greater than 120" do
+    performance = Performance.new(
+      performer: @performer,
+      start_time: Time.zone.parse("12:00"),
+      duration: 125
+    )
+
+    assert_not performance.valid?
+    assert_includes performance.errors[:duration], "は120以下で入力してください"
+  end
+
   # 同じ日・同じステージで時間が重複する出演情報は作成できない
   test "is invalid when time overlaps on same day and stage" do
     performance = Performance.new(
@@ -215,22 +227,6 @@ class PerformanceTest < ActiveSupport::TestCase
     performance = create_timed_performance("01:30", duration: 30)
 
     assert_equal "25:30", performance.formatted_start_time
-  end
-
-  # 24時間の出演は終了時刻が同じ時計でも翌日として扱う
-  test "treats duration 1440 as next-date end time in festival minutes" do
-    performance = Performance.new(
-      performer: @performer,
-      start_time: Time.zone.parse("10:00"),
-      duration: 1440
-    )
-    performance.valid?
-    performance.save!
-    performance.reload
-
-    assert_equal 10, performance.end_time.hour
-    assert_equal 0, performance.end_time.min
-    assert_equal performance.festival_start_minutes + 1440, performance.festival_end_minutes
   end
 
   private

--- a/test/models/performance_test.rb
+++ b/test/models/performance_test.rb
@@ -210,6 +210,13 @@ class PerformanceTest < ActiveSupport::TestCase
     assert performance.valid?
   end
 
+  # 0時過ぎの開始時刻は24時台で表示する
+  test "formats overnight start time with hour 24 or later" do
+    performance = create_timed_performance("01:30", duration: 30)
+
+    assert_equal "25:30", performance.formatted_start_time
+  end
+
   private
     def create_timed_performance(start_hm, duration:, stage: @stage, performer: @performer, day: @day)
       Performance.create!(

--- a/test/models/performance_test.rb
+++ b/test/models/performance_test.rb
@@ -217,6 +217,22 @@ class PerformanceTest < ActiveSupport::TestCase
     assert_equal "25:30", performance.formatted_start_time
   end
 
+  # 24時間の出演は終了時刻が同じ時計でも翌日として扱う
+  test "treats duration 1440 as next-date end time in festival minutes" do
+    performance = Performance.new(
+      performer: @performer,
+      start_time: Time.zone.parse("10:00"),
+      duration: 1440
+    )
+    performance.valid?
+    performance.save!
+    performance.reload
+
+    assert_equal 10, performance.end_time.hour
+    assert_equal 0, performance.end_time.min
+    assert_equal performance.festival_start_minutes + 1440, performance.festival_end_minutes
+  end
+
   private
     def create_timed_performance(start_hm, duration:, stage: @stage, performer: @performer, day: @day)
       Performance.create!(

--- a/test/models/performance_test.rb
+++ b/test/models/performance_test.rb
@@ -153,4 +153,71 @@ class PerformanceTest < ActiveSupport::TestCase
 
     assert @performance_for_overlaps.valid?
   end
+
+  # 同じ開催日では22:00のあとに01:00が並ぶ
+  test "orders 01:00 after 22:00 on the same day" do
+    evening = create_timed_performance("22:00", duration: 30)
+    overnight = create_timed_performance("01:00", duration: 30)
+
+    ordered = @performer.performances.ordered_for_performer_detail.to_a
+    assert_operator ordered.index(evening), :<, ordered.index(overnight)
+
+    timetable_ordered = Performance.timetable_ready_for_event_on_date(@performer.event, @day.date).to_a
+    assert_operator timetable_ordered.index(evening), :<, timetable_ordered.index(overnight)
+  end
+
+  # 日付境界の6:00は5:00より前に並ぶ
+  test "orders 05:00 after 06:00 on the same day" do
+    six = create_timed_performance("06:00", duration: 30)
+    five = create_timed_performance("05:00", duration: 30)
+
+    ordered = @performer.performances.ordered_for_performer_detail.to_a
+    assert_operator ordered.index(six), :<, ordered.index(five)
+  end
+
+  # 昼間の出演は従来どおり開始時刻順
+  test "keeps daytime performances in clock order" do
+    ordered = @performer.performances.ordered_for_performer_detail.to_a
+    assert_equal [ performances(:one), performances(:one_second) ], ordered
+  end
+
+  # 0時をまたぐ出演は深夜帯の重複を検出する
+  test "is invalid when overnight performance overlaps after midnight" do
+    create_timed_performance("23:00", duration: 120, stage: @another_stage)
+    overlapping = Performance.new(
+      performer: performers(:two),
+      day: @day,
+      stage: @another_stage,
+      start_time: Time.zone.parse("00:30"),
+      duration: 30
+    )
+
+    assert_not overlapping.valid?
+    assert_includes overlapping.errors[:base], "同じ時間帯に他の出演情報が存在します"
+  end
+
+  # 0時をまたぐ出演でも、前の時間帯と接していなければ作成できる
+  test "is valid when overnight performance does not overlap evening slot" do
+    create_timed_performance("23:00", duration: 120, stage: @another_stage)
+    performance = Performance.new(
+      performer: performers(:two),
+      day: @day,
+      stage: @another_stage,
+      start_time: Time.zone.parse("22:00"),
+      duration: 60
+    )
+
+    assert performance.valid?
+  end
+
+  private
+    def create_timed_performance(start_hm, duration:, stage: @stage, performer: @performer, day: @day)
+      Performance.create!(
+        performer: performer,
+        stage: stage,
+        day: day,
+        start_time: Time.zone.parse(start_hm),
+        duration: duration
+      )
+    end
 end

--- a/test/models/performance_test.rb
+++ b/test/models/performance_test.rb
@@ -90,12 +90,23 @@ class PerformanceTest < ActiveSupport::TestCase
     assert_includes performance.errors[:duration], "は5以上で入力してください"
   end
 
+  # durationが120の場合は有効
+  test "is valid when duration is 120" do
+    performance = Performance.new(
+      performer: @performer,
+      start_time: Time.zone.parse("12:00"),
+      duration: 120
+    )
+
+    assert performance.valid?
+  end
+
   # durationが120より大きい場合はエラー
   test "is invalid when duration is greater than 120" do
     performance = Performance.new(
       performer: @performer,
       start_time: Time.zone.parse("12:00"),
-      duration: 125
+      duration: 121
     )
 
     assert_not performance.valid?

--- a/test/models/performer_test.rb
+++ b/test/models/performer_test.rb
@@ -24,4 +24,24 @@ class PerformerTest < ActiveSupport::TestCase
       performance.reload
     end
   end
+
+  # 出演情報は開催日と6時起点の開始時刻順
+  test "performances are ordered by festival day and time" do
+    overnight = Performance.create!(
+      performer: @performer,
+      day: @day,
+      stage: stages(:two),
+      start_time: Time.zone.parse("01:00"),
+      duration: 30
+    )
+    evening = Performance.create!(
+      performer: @performer,
+      day: @day,
+      stage: stages(:two),
+      start_time: Time.zone.parse("22:00"),
+      duration: 30
+    )
+
+    assert_operator @performer.performances.index(evening), :<, @performer.performances.index(overnight)
+  end
 end

--- a/test/models/performer_test.rb
+++ b/test/models/performer_test.rb
@@ -44,4 +44,25 @@ class PerformerTest < ActiveSupport::TestCase
 
     assert_operator @performer.performances.index(evening), :<, @performer.performances.index(overnight)
   end
+
+  # 開催日が違う場合は、遅い日の早い時刻より先に並ぶ
+  test "performances on an earlier day come before a later day" do
+    later_day = Performance.create!(
+      performer: @performer,
+      day: days(:two),
+      stage: stages(:two),
+      start_time: Time.zone.parse("10:00"),
+      duration: 30
+    )
+    earlier_day_overnight = Performance.create!(
+      performer: @performer,
+      day: @day,
+      stage: stages(:two),
+      start_time: Time.zone.parse("01:00"),
+      duration: 30
+    )
+
+    ordered = @performer.performances.to_a
+    assert_operator ordered.index(earlier_day_overnight), :<, ordered.index(later_day)
+  end
 end

--- a/test/services/timetable_creator_test.rb
+++ b/test/services/timetable_creator_test.rb
@@ -49,4 +49,32 @@ class TimetableCreatorTest < ActionDispatch::IntegrationTest
       )
     )
   end
+
+  # 0時をまたぐ出演は6時起点の順でdurationを計算する
+  test "calculates duration across midnight in festival time order" do
+    json = {
+      "stages" => [
+        {
+          "stage_name" => "OvernightStage",
+          "performances" => [
+            { "performer_name" => "LateNight", "start_time" => "00:10" },
+            { "performer_name" => "Evening", "start_time" => "23:50" }
+          ]
+        }
+      ]
+    }
+
+    result = TimetableCreator.create_from_json(
+      json: json,
+      event: @no_performance_event,
+      day: @no_performance_event_day
+    )
+
+    assert result[:success]
+    performances = Performance.joins(:performer).where(performers: { event_id: @no_performance_event.id })
+    evening = performances.find { |performance| performance.start_time.hour == 23 && performance.start_time.min == 50 }
+    late_night = performances.find { |performance| performance.start_time.hour == 0 && performance.start_time.min == 10 }
+    assert_equal 10, evening.duration
+    assert_equal 10, late_night.duration
+  end
 end


### PR DESCRIPTION
## Summary
- 午前6時を開催日の日付境界とし、`00:00`〜`05:59` を同じ開催日の深夜帯として並べる
- タイムテーブルの時刻列・位置・高さ、重複判定、開始時刻セレクト、AI作成の duration 計算を同じ順序に揃える
- `start_time` カラムは変更せず、表示と並びだけを6時起点に変換する

Closes: #401

## Test plan
- [x] 昼間のみのタイムテーブル（例: 10:00〜22:00）が従来どおり表示される
- [x] 同じ開催日に 22:00 と 25:00 を入れると、時刻列が 22, 23, 24, 25 になり 25:00 が下に来る
- [x] 出演者詳細の出演一覧でも 22:00 のあとに 25:00 が並ぶ
- [x] 開始時刻セレクトが 06 始まりで、29 が末尾になる
- [x] 23:00〜25:00 と 24:30 が同じステージなら重複エラーになる
- [x] 画像から作成で 23:50 と 24:10 があるとき、出演時間が正の値になる


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 深夜帯を含む時刻を「25時」などのフェス開催日基準で入力・表示できるようになりました。
  * 日付をまたぐ出演を正しい時刻順・長さでタイムテーブルに表示します。
  * タイムテーブルの時間枠や配置が、深夜公演を含めて正確に計算されるようになりました。

* **バグ修正**
  * 出演情報の編集時、保存済みの深夜時刻が正しい表示時刻で選択されるようになりました。
  * 出演者一覧やタイムテーブルの時刻表示・並び順を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->