### PR TITLE
chore: CIからlibvipsインストールを外す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,9 +78,6 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
-      - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips42
-
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -117,9 +114,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
-
-      - name: Install libvips
-        run: sudo apt-get update && sudo apt-get install --no-install-recommends -y libvips42
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/Gemfile
+++ b/Gemfile
@@ -41,11 +41,6 @@ gem "kamal", require: false
 # Add HTTP asset caching/compression and X-Sendfile acceleration to Puma [https://github.com/basecamp/thruster/]
 gem "thruster", require: false
 
-# Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
-gem "image_processing", "~> 2.0"
-# Rails 8.1.3.1+ の Active Storage が起動時に要求する（libvips >= 8.13 も必要）
-gem "ruby-vips", ">= 2.2.1", require: false
-
 # 追記
 gem "rexml", ">= 3.4"
 gem "thor", ">= 1.4"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -135,13 +135,6 @@ GEM
       logger
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
-    ffi (1.17.4-aarch64-linux-gnu)
-    ffi (1.17.4-aarch64-linux-musl)
-    ffi (1.17.4-arm-linux-gnu)
-    ffi (1.17.4-arm-linux-musl)
-    ffi (1.17.4-arm64-darwin)
-    ffi (1.17.4-x86_64-linux-gnu)
-    ffi (1.17.4-x86_64-linux-musl)
     fugit (1.13.0)
       et-orbi (~> 1.4)
       raabro (~> 1.4)
@@ -151,7 +144,6 @@ GEM
       logger
     i18n (1.15.2)
       concurrent-ruby (~> 1.0)
-    image_processing (2.0.3)
     importmap-rails (2.2.3)
       actionpack (>= 6.0.0)
       activesupport (>= 6.0.0)
@@ -382,9 +374,6 @@ GEM
       rubocop-performance (>= 1.24)
       rubocop-rails (>= 2.30)
     ruby-progressbar (1.13.0)
-    ruby-vips (2.3.0)
-      ffi (~> 1.12)
-      logger
     rubyzip (3.4.1)
     securerandom (0.4.1)
     selenium-webdriver (4.47.0)
@@ -500,7 +489,6 @@ DEPENDENCIES
   capybara
   debug
   devise
-  image_processing (~> 2.0)
   importmap-rails
   jbuilder
   kamal
@@ -518,7 +506,6 @@ DEPENDENCIES
   rinku
   rqrcode
   rubocop-rails-omakase
-  ruby-vips (>= 2.2.1)
   selenium-webdriver
   sentry-rails (~> 6.7)
   sentry-ruby (~> 6.7)

--- a/config/application.rb
+++ b/config/application.rb
@@ -14,6 +14,9 @@ module Minnanotimetable
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 8.1
 
+    # 画像添付・変換は使わない。:vips のままだと起動時に libvips / ruby-vips が必要になる
+    config.active_storage.variant_processor = :disabled
+
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.

--- a/test/config/active_storage_test.rb
+++ b/test/config/active_storage_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class ActiveStorageConfigTest < ActiveSupport::TestCase
+  test "画像変換は無効（libvipsなしで起動できるようにする）" do
+    assert_equal :disabled, ActiveStorage.variant_processor
+  end
+end


### PR DESCRIPTION
## Summary
- Active Storageの画像変換を使っていないため `variant_processor` を `:disabled` にした
- 起動時に libvips を要求する `image_processing` / `ruby-vips` を Gemfile から削除した
- test / system-test ジョブの `libvips42` インストールを削除し、apt 待ちをなくした

## Test plan
- [x] CIの test ジョブが libvips インストールなしで通ること
- [x] CIの system-test ジョブが libvips インストールなしで通ること（以前は apt に十数分かかっていた）
- [x] ローカルで `bin/rails test` と `bin/rails test:system` が通ること


Made with [Cursor](https://cursor.com)