### PR TITLE
fix: マイタイムテーブルの空状態を画面中央に揃える

### DIFF
--- a/app/views/my_timetables/show.html.erb
+++ b/app/views/my_timetables/show.html.erb
@@ -17,7 +17,7 @@
     <% end %>
   </nav>
 <% end %>
-<div id="my_timetable">
+<div id="my_timetable" class="h-full">
   <%= render "content" %>
 </div>
 <%# 下部タブメニュー %>

--- a/app/views/performance_favorites/refresh.turbo_stream.erb
+++ b/app/views/performance_favorites/refresh.turbo_stream.erb
@@ -9,7 +9,7 @@
       } %>
 <% if @refresh_my_timetable %>
   <%= turbo_stream.replace "my_timetable" do %>
-    <div id="my_timetable">
+    <div id="my_timetable" class="h-full">
       <%= render "my_timetables/content" %>
     </div>
   <% end %>

--- a/test/controllers/my_timetables_controller_test.rb
+++ b/test/controllers/my_timetables_controller_test.rb
@@ -57,7 +57,18 @@ class MyTimetablesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_select "body.h-svh.overflow-hidden"
     assert_select "main.min-h-0.overflow-hidden"
+    assert_select "div#my_timetable.h-full"
     assert_select "div.flex-1.min-h-0.overflow-auto.overscroll-none"
+  end
+
+  # 出演情報0件の空状態は上下左右中央に表示する
+  test "empty my timetable centers the empty state" do
+    get show_my_timetable_path(event_key: @no_performance_event.event_key, username: @user.username)
+    assert_response :success
+    assert_select "div#my_timetable.h-full" do
+      assert_select "div.h-full.flex.flex-col.items-center.justify-center"
+    end
+    assert_select "p", text: /出演情報をお気に入り登録すると/
   end
 
   test "should not get unpublished my_timetable with logout" do

--- a/test/controllers/performance_favorites_controller_test.rb
+++ b/test/controllers/performance_favorites_controller_test.rb
@@ -61,6 +61,7 @@ class PerformanceFavoritesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
     assert_select "turbo-stream[action='replace'][target=my_timetable]" do
+      assert_select "div#my_timetable.h-full"
       assert_select "a#my_timetable_performance_#{performance.id}"
     end
   end
@@ -104,6 +105,7 @@ class PerformanceFavoritesControllerTest < ActionDispatch::IntegrationTest
     end
     assert_response :success
     assert_select "turbo-stream[action='replace'][target=my_timetable]" do
+      assert_select "div#my_timetable.h-full"
       assert_select "a#my_timetable_performance_#{performance.id}", count: 0
     end
   end


### PR DESCRIPTION
## Summary
- マイタイムテーブルの出演情報0件時、案内テキストが中央上揃えになっていたのを上下左右中央揃えに戻す
- `#484` で追加した `#my_timetable` ラッパーに `h-full` が無く、空状態の `h-full` / `justify-center` が効いていなかった

## Test plan
- [x] 出演情報をお気に入りしていないマイタイムテーブルを開き、案内テキストが画面の上下左右中央にあることを確認する
- [x] お気に入りがあるマイタイムテーブルの表示・スクロールが崩れていないことを確認する
- [x] マイタイムテーブル上でお気に入り登録・解除してもレイアウトが維持されることを確認する

Closes: #504

Made with [Cursor](https://cursor.com)