### PR TITLE
docs: モーダル編集機能のdocstringを追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -34,19 +34,29 @@ class ApplicationController < ActionController::Base
   # ビューでpreview_environment?メソッドを使用できるようにする
   helper_method :preview_environment?
 
-  # レイアウトのturbo-frame#modal からのリクエストかどうか
+  # レイアウトの turbo-frame#modal からのリクエストかどうか。
+  #
+  # Turbo-Frame ヘッダーが "modal" のとき true。show/edit のモーダル描画や
+  # layout: false の判定に使う。
   def modal_turbo_frame?
     turbo_frame_request_id == "modal"
   end
   helper_method :modal_turbo_frame?
 
-  # モーダル内の編集表示・送信か（turbo-frame#modal または from_modal 付き送信）
+  # モーダル内の編集表示・送信かどうか。
+  #
+  # turbo-frame#modal からの GET、または hidden field from_modal 付きの
+  # PATCH/DELETE を指す。フォームの _top 送信後の再描画でも true になる。
   def modal_edit_context?
     modal_turbo_frame? || modal_form_submission?
   end
   helper_method :modal_edit_context?
 
-  # モーダル内フォーム送信後の戻り先（タイムテーブルなど元のページ）
+  # モーダル内フォーム送信後の戻り先 URL。
+  #
+  # from_modal 付きの更新・削除成功時にタイムテーブル等へ戻るために使う。
+  # Referer は url_from で検証し、外部 URL や不正な値は無視して
+  # タイムテーブルへフォールバックする。
   def modal_return_url
     url_from(request.referer) || show_timetable_path(@event.event_key)
   end
@@ -58,18 +68,26 @@ class ApplicationController < ActionController::Base
   helper_method :show_name_confirmation_modal?
 
   private
-    # モーダル内の編集フォームから送信されたか（turbo-frame#modal の _top 送信）
+    # モーダル内編集フォームからの送信かどうか。
+    #
+    # フォームは turbo-frame="_top" で送るため Turbo-Frame ヘッダーは付かない。
+    # hidden field from_modal でモーダル起点の送信を識別する。
     def modal_form_submission?
       params[:from_modal].present?
     end
 
-    # モーダル内フォームのバリデーションエラー時に #modal を差し替える
+    # モーダル内フォームのバリデーションエラー時に #modal を差し替える。
+    #
+    # _top 送信の 422 では通常 edit が全ページを置き換えてしまうため、
+    # turbo-stream でモーダル枠だけ編集フォーム＋エラーを返す。
     def render_modal_edit_unprocessable(modal_partial)
       render turbo_stream: turbo_stream.replace("modal", partial: modal_partial),
              status: :unprocessable_entity
     end
 
-    # モーダル編集の失敗時はモーダル差し替え、通常編集は edit を返す
+    # 編集失敗時のレスポンスをモーダル送信か通常送信かで切り替える。
+    #
+    # from_modal なら render_modal_edit_unprocessable、それ以外は edit を返す。
     def render_edit_unprocessable(modal_partial)
       if modal_form_submission?
         render_modal_edit_unprocessable(modal_partial)

--- a/app/controllers/performances_controller.rb
+++ b/app/controllers/performances_controller.rb
@@ -62,6 +62,8 @@ class PerformancesController < ApplicationController
     @performance.start_time_minute = @performance.start_time&.min
   end
 
+  # 出演情報更新。
+  # from_modal 送信時は成功後 modal_return_url へ、失敗時は turbo-stream で #modal を差し替える。
   def update
     if @performance.update(performance_params_for_update)
       if modal_form_submission?
@@ -77,6 +79,8 @@ class PerformancesController < ApplicationController
     end
   end
 
+  # 出演情報削除。
+  # from_modal 送信時は modal_return_url へ、通常時は出演者詳細へ戻る。
   def destroy
     @performer = @performance.performer
     @performance.destroy!

--- a/app/controllers/performers_controller.rb
+++ b/app/controllers/performers_controller.rb
@@ -80,6 +80,8 @@ class PerformersController < ApplicationController
   def edit
   end
 
+  # 出演者更新。
+  # from_modal 送信時は成功後 modal_return_url へ、失敗時は turbo-stream で #modal を差し替える。
   def update
     # フォームのタグ名を取得
     tag_name = params.dig(:performer, :performer_name_tag_attributes, :name)&.strip
@@ -124,6 +126,8 @@ class PerformersController < ApplicationController
     end
   end
 
+  # 出演者削除。
+  # from_modal 送信時は modal_return_url へ、通常時は出演者一覧へ戻る。
   def destroy
     @performer.destroy!
     if modal_form_submission?

--- a/app/controllers/stages_controller.rb
+++ b/app/controllers/stages_controller.rb
@@ -72,7 +72,8 @@ class StagesController < ApplicationController
   def edit
   end
 
-  # ステージ編集処理
+  # ステージ更新。
+  # from_modal 送信時は成功後 modal_return_url へ、失敗時は turbo-stream で #modal を差し替える。
   def update
     # フォームのタグ名を取得
     tag_name = params.dig(:stage, :stage_name_tag_attributes, :name)&.strip
@@ -117,7 +118,8 @@ class StagesController < ApplicationController
     end
   end
 
-  # ステージ削除処理
+  # ステージ削除処理。
+  # from_modal 送信時は modal_return_url へ、通常時はステージ一覧へ戻る。
   def destroy
     @stage.destroy!
     if modal_form_submission?

--- a/app/javascript/controllers/modal_controller.js
+++ b/app/javascript/controllers/modal_controller.js
@@ -2,7 +2,10 @@ import { Controller } from "@hotwired/stimulus"
 
 // Connects to data-controller="modal"
 export default class extends Controller {
-  // モーダルを開く
+  /**
+   * モーダルを開く。
+   * リンクのデフォルト遷移を止め、turbo-frame#modal の src に URL を設定する。
+   */
   open(event) {
     event.preventDefault() // linkの遷移を止める
     const url = event.currentTarget.dataset.url // 開きたいURLを取得
@@ -10,7 +13,11 @@ export default class extends Controller {
     if (frame) frame.src = url // Turboで内容を読み込む
   }
 
-  // モーダル内のリンク遷移（詳細→編集など）
+  /**
+   * モーダル内リンクの遷移（詳細→編集など）。
+   * data-turbo-frame だけでは Frame 差し替え後にリンクが効かなくなるため、
+   * frame.src を直接更新してページ遷移せずモーダル内で差し替える。
+   */
   navigate(event) {
     event.preventDefault()
     const url = event.currentTarget.href
@@ -20,7 +27,10 @@ export default class extends Controller {
     if (frame) frame.src = url
   }
 
-  // モーダルをクローズする
+  /**
+   * モーダルを閉じる。
+   * turbo-frame#modal の中身を空にしてオーバーレイを消す。
+   */
   close() {
     // モーダル全体を取得
     const frame = this.element.closest("turbo-frame")
@@ -28,7 +38,10 @@ export default class extends Controller {
     if (frame) frame.innerHTML = ""
   }
 
-  // 背景への click 伝播を止める
+  /**
+   * モーダル本体クリック時に背景への click 伝播を止める。
+   * コンテンツ領域のクリックでモーダルが閉じないようにする。
+   */
   stop(event) {
     event.stopPropagation()
   }


### PR DESCRIPTION
## Summary

- PR #508 の Code Rabbit 指摘（Docstring Coverage 57% → 80% 未満）へのフォローアップ
- モーダル編集・遷移・バリデーションエラー処理の意図をコメントで追記
  - `ApplicationController` のモーダル関連ヘルパー・private メソッド
  - `PerformersController` / `StagesController` / `PerformancesController` の update・destroy
  - `modal_controller.js` の open / navigate / close / stop

Related to #508

## Test plan

- [x] ドキュメント追加のみのためテスト変更なし
- [ ] Code Rabbit の Docstring Coverage 警告が解消されることを確認


Made with [Cursor](https://cursor.com)